### PR TITLE
Fix Camera Distance StepSize

### DIFF
--- a/assets/pak6_VorpalFix/controls_pc_deu.urc
+++ b/assets/pak6_VorpalFix/controls_pc_deu.urc
@@ -1,0 +1,1552 @@
+menu "controls" 640 480 NONE 0.5
+fadeoverlay 0.5
+bgcolor 0 0 0 1
+borderstyle NONE
+bgfill 0 0 0 1
+fullscreen 1
+// vidmode 3
+
+showcommand "widgetcommand TitleBar activategroup group_main\n"
+showcommand "widgetcommand alice3d setanim idle_stand_rocktoes\n"
+
+allowactivate	true
+keycommand		1 "widgetcommand TitleBar activategroup group_video\n"
+keycommand		2 "widgetcommand TitleBar activategroup group_audio\n"
+keycommand		3 "widgetcommand TitleBar activategroup group_control_pc\n"
+keycommand		4 "widgetcommand TitleBar activategroup group_game\n"
+
+// Mirror background
+resource
+Label
+{
+	name			"Default"
+	rect			337 94 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/reflect_lightning
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			337 349 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/reflect_2.tga
+	allowactivate	false
+}
+
+resource
+Alice3D
+{
+	name			"alice3d"
+	rect			0 0 640 480
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	allowactivate	false
+}
+
+// Background
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	0 ui/control/controlA
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	1 ui/control/controlB
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 0 128 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	2 ui/control/controlC
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			0 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	3 ui/control/controlD
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	4 ui/control/controlE
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 256 128 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	5 ui/control/controlF
+	allowactivate	false
+}
+
+// bulb
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/bulb_glow
+	allowactivate	false
+}
+
+// glowing heart
+resource
+Label
+{
+	name			"Default"
+	rect			445 22 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/glowing_heart
+	allowactivate	false
+}
+
+// glowing eyes overlay
+resource
+Label
+{
+	name			"Default"
+	rect			454 403 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	font			"asrafel"
+	fontjustify		left center
+	shader			ui/control/skull_glow
+	allowactivate	false
+}
+
+// --------------------------------------
+// --------------------------------------
+// MAIN GROUP
+// --------------------------------------
+// --------------------------------------
+
+// RETURN BUTTON
+resource
+Button
+{
+	title			"Zurück"
+	name			"Default"
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu\n"
+	groupid			"group_main"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
+	allowactivate	false
+}
+
+// head
+resource
+Label
+{
+	name			"Default"
+	rect			48 63 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	6 ui/control/head_1
+	groupid			"group_main"
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"TitleBar"
+	rect			48 319 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/head_2
+	groupid			"group_main"
+	
+	allowactivate	false
+} 
+resource
+Label
+{
+	name			"Default"
+	rect			75 330 24 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"ui/control/hslider_prev"
+	groupid			"group_main"
+	allowactivate	false
+} 
+resource
+Label
+{
+	name			"Default"
+	rect			257 330 24 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"ui/control/hslider_next"
+	groupid			"group_main"
+	allowactivate	false
+} 
+// hotspots
+resource
+Button
+{
+	name			"Default"
+	rect			134 143 37 39
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		2
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_video\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_video\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			172 125 56 68
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		3
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_audio\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_audio\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			213 181 50 58
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		4
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_control\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_control_pc\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			138 94 32 39
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		1
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_game\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_game\n"
+	groupid			"group_main"
+}
+
+resource
+Label
+{
+	name			"Default"
+	rect			121 83 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/game_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			120 134 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/video_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			166 129 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/audio_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			210 172 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/control_options
+	noinput
+	allowactivate	false
+}
+
+// --------------------------------------
+// --------------------------------------
+// CONTROL GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Zurück"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			37 8
+	ordernumber		6
+}
+
+// RESET BUTTON
+resource
+Button
+{
+	title			"Zurücksetzen"
+	name			"Default"
+	rect			170 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/plaque
+	hovershader		ui/buttons/plaque_hover
+	stuffcommand	"exec default_pc.cfg; vid_restart; popmenu 0\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			13 8
+	fontscale		0.8
+	ordernumber		7
+}
+
+// JOYSTICK
+resource
+Button
+{
+	title			"Controller"
+	name			"Default"
+	rect			290 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/plaque
+	hovershader		ui/buttons/plaque_hover
+	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			13 8
+	fontscale		0.8
+	ordernumber		34
+}
+
+// BIND LIST
+resource
+FakkBindList
+{
+	title			"BindList"
+	name			"BindList"
+	rect			62 70 230 300
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"3D_BORDER"
+	filename		ui/bind.scr
+	font			"asrafel"
+	groupid			"group_control_pc"
+	ordernumber		5
+}
+
+// APPLY BUTTON
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 640 480
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"controls_pc"
+	groupid			"group_control"
+}
+resource
+Label
+{
+	title			"Alternativangriff /"
+	name			"Default"
+	rect			0 140 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nach oben klettern"
+	name			"Default"
+	rect			0 155 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nächste Waffe"
+	name			"Default"
+	rect			0 175 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Bewegen"
+	name			"Default"
+	rect			0 270 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Menünavigation"
+	name			"Default"
+	rect			120 376 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Drehen/Zielen"
+	name			"Default"
+	rect			350 376 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Angreifen /"
+	name			"Default"
+	rect			467 290 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nach unten klettern"
+	name			"Default"
+	rect			467 305 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Springen /"
+	name			"Default"
+	rect			467 259 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nach oben schwimmen"
+	name			"Default"
+	rect			467 274 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Verwenden /"
+	name			"Default"
+	rect			467 228 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nach unten schwimmen"
+	name			"Default"
+	rect			467 243 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Alternativangriff /"
+	name			"Default"
+	rect			467 198 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nach oben klettern"
+	name			"Default"
+	rect			467 213 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Vorh. Waffe"
+	name			"Default"
+	rect			467 175 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Angreifen /"
+	name			"Default"
+	rect			467 140 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nach unten klettern"
+	name			"Default"
+	rect			467 155 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Pause/Menü verlassen"
+	name			"Default"
+	rect			270 110 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		center center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Steuerung"
+	name			"Default"
+	rect			50 50 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left center
+	fontscale		2.0
+	dropshadow		1
+}
+resource
+Button
+{
+	title			"Zurück"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/plaque
+	hovershader		ui/buttons/plaque_hover
+	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_control_pc\n"
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		35
+} 
+// --------------------------------------
+// --------------------------------------
+// VIDEO GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Anwenden"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_video; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_video"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		15
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Abbrechen"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_video; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_video"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		16
+}
+
+// RESOLUTION
+resource
+Label
+{
+	title			"Auflösung"
+	name			"ResolutionTxt"
+	rect			68 78 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 94 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+	
+
+	highlighttextwidget "ResolutionTxt"
+	ordernumber		8
+
+	linkcvar		"r_mode"
+}
+
+// COLOR DEPTH
+resource
+Label
+{
+	title			"Farbtiefe"
+	name			"ColorTxt"
+	rect			68 118 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 134 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+
+	highlighttextwidget "ColorTxt"
+	ordernumber		9
+
+	linkcvar		"r_colorbits"
+	additem			16 16Bit
+	additem			32 32Bit
+	
+}
+
+// FULLSCREEN
+resource
+Label
+{
+	title			"Vollbildschirm"
+	name			"FullscreenTxt"
+	rect			68 158 210 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 158 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"r_fullscreen"
+
+	highlighttextwidget "FullscreenTxt"
+	ordernumber		10
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+	
+}
+
+// BRIGHTNESS
+resource
+Label
+{
+	title			"Helligkeit"
+	name			"Brightness"
+	rect			68 188 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 204 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	linkcvar		"r_gamma"
+	slidertype		float
+	setrange		.5 1.5
+	stepsize		.05
+	font			"asrafel"
+	
+
+	highlighttextwidget "Brightness"
+	ordernumber		11
+}
+
+// TEXTURE DETAIL
+resource
+Label
+{
+	title			"Texturen-Detail"
+	name			"Texture_Detail"
+	rect			68 238 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 254 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	linkcvar		"r_picmip"
+	slidertype		integer
+	setrange		3 0
+	stepsize		-1
+	font			"asrafel"
+	
+
+	highlighttextwidget "Texture_Detail"
+	ordernumber		12
+}
+
+// TEXTURE DEPTH
+resource
+Label
+{
+	title			"Texturen"
+	name			"Texture_Bits"
+	rect			68 278 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 294 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"r_texturebits"
+	additem			16 16Bit
+	additem			32 32Bit
+	
+
+	highlighttextwidget "Texture_Bits"
+	ordernumber		13
+}
+
+// DETAIL TEXTURES
+resource
+Label
+{
+	title			"Detaillierte Texturen"
+	name			"DetailTxt"
+	rect			68 338 210 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 334 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"r_detailtextures"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+	
+
+	highlighttextwidget "DetailTxt"
+	ordernumber		14
+}
+
+// --------------------------------------
+// --------------------------------------
+// AUDIO GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Anwenden"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_audio; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_audio"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		23
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Abbrechen"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_audio; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_audio"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		24
+}
+
+// SOUND DRIVER
+resource
+Label
+{
+	title			"Soundtreiber"
+	name			"DriverTxt"
+	rect			68 78 200 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 94 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_milesdriver"
+	additem			miles
+	additem			dolby
+	additem			a3d
+	additem			a3d2
+	additem			eax
+	additem			eax2
+
+	highlighttextwidget "DriverTxt"
+	ordernumber		17
+}
+
+// MUSIC VOLUME
+resource
+Label
+{
+	title			"Lautstärke Musik"
+	name			"Music_Volume"
+	rect			68 168 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 184 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	linkcvar		"s_musicvolume"
+	slidertype		float
+	setrange		0 1
+	stepsize		.05
+	font			"asrafel"
+
+	highlighttextwidget "Music_Volume"
+	ordernumber		19
+}
+
+// SFX VOLUME
+resource
+Label
+{
+	title			"Lautstärke Soundeffekte"
+	name			"SFX_Volume"
+	rect			68 208 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 224 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	linkcvar		"s_volume"
+	slidertype		float
+	setrange		0 1
+	stepsize		.05
+	font			"asrafel"
+
+	highlighttextwidget "SFX_Volume"
+	ordernumber		20
+}
+
+// SPEAKER TYPE
+resource
+Label
+{
+	title			"Lautsprechertyp"
+	name			"SpeakerTxt"
+	rect			68 118 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 134 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_speaker_type"
+	additem			0 "Normal"
+	additem			1 "Kopfhörer"
+	additem			3 "Surround"
+	additem			4 "Vier Lautsprecher"
+
+	highlighttextwidget "SpeakerTxt"
+	ordernumber		18
+}
+
+// QUALITY
+resource
+Label
+{
+	title			"Qualität"
+	name			"QualityTxt"
+	rect			68 258 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 274 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_khz"
+	additem			22 "22 khz"
+	additem			44 "44 khz"
+
+	highlighttextwidget "QualityTxt"
+	ordernumber		21
+
+}
+
+// FORCE 8BIT
+resource
+Label
+{
+	title			"8 Bit verwenden"
+	name			"8BitsTxt"
+	rect			68 298 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 298 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"s_loadas8bit"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	highlighttextwidget "8BitsTxt"
+	ordernumber		22
+}
+
+// --------------------------------------
+// --------------------------------------
+// GAME OPTIONS GROUP
+// --------------------------------------
+// --------------------------------------
+
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Anwenden"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_game; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_game"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		32
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Abbrechen"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_game; toggleconsole; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_game"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		33
+}
+
+// SENSITIVITY
+resource
+Label
+{
+	title			"Empfindlichkeit"
+	name			"Mouse_Sensitivity"
+	rect			68 80 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+	fontspacing		0.5
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 100 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	linkcvar		"sensitivity"
+	setrange		1 20
+	slidertype		float
+	stepsize		1
+	font			"asrafel"
+
+	highlighttextwidget "Mouse_Sensitivity"
+	ordernumber		25
+}
+
+// INVERT MOUSE
+resource
+Label
+{
+	title			"Mausblick umkehren"
+	name			"InvertMouseTxt"
+	rect			68 130 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 130 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"m_invert_pitch"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	checked_command		"set m_pitch -0.022"
+	unchecked_command	"set m_pitch 0.022"
+
+	highlighttextwidget "InvertMouseTxt"
+	ordernumber		26
+
+}
+
+// CAMERA DISTANCE
+resource
+Label
+{
+	title			"Kameradistanz"
+	name			"Camera_Distance"
+	rect			68 158 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	rect			88 178 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	linkcvar		"cg_cameradist"
+	slidertype		float
+	setrange		76 192
+	stepsize		4
+	font			"asrafel"
+
+	highlighttextwidget "Camera_Distance"
+	ordernumber		27
+
+}
+
+// ALWAYS RUN
+resource
+Label
+{
+	title			"Immer Rennen"
+	name			"AlwaysRunTxt"
+	rect			68 210 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 210 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"cl_run"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "AlwaysRunTxt"
+	ordernumber		28
+
+}
+
+// JUMP RETICLE
+resource
+Label
+{
+	title			"Sprunganzeige"
+	name			"JumpReticleTxt"
+	rect			68 270 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 270 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_jumpreticle"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "JumpReticleTxt"
+	ordernumber		29
+}
+
+// TARGET RETICLE
+resource
+Label
+{
+	title			"Fadenkreuz"
+	name			"TargetReticleTxt"
+	rect			68 290 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 290 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_crosshair"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "TargetReticleTxt"
+	ordernumber		30
+}
+
+// SUBTITLES
+resource
+Label
+{
+	title			"Untertitel"
+	name			"SubtitlesTxt"
+	rect			68 330 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 330 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_subtitles"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "SubtitlesTxt"
+	ordernumber		31
+}
+
+end.
+ÍÍÂ¬

--- a/assets/pak6_VorpalFix/controls_pc_esn.urc
+++ b/assets/pak6_VorpalFix/controls_pc_esn.urc
@@ -1,0 +1,1524 @@
+menu "controls" 640 480 NONE 0.5
+fadeoverlay 0.5
+bgcolor 0 0 0 1
+borderstyle NONE
+bgfill 0 0 0 1
+fullscreen 1
+// vidmode 3
+
+showcommand "widgetcommand TitleBar activategroup group_main\n"
+showcommand "widgetcommand alice3d setanim idle_stand_rocktoes\n"
+
+allowactivate	true
+keycommand		1 "widgetcommand TitleBar activategroup group_video\n"
+keycommand		2 "widgetcommand TitleBar activategroup group_audio\n"
+keycommand		3 "widgetcommand TitleBar activategroup group_control_pc\n"
+keycommand		4 "widgetcommand TitleBar activategroup group_game\n"
+
+// Mirror background
+resource
+Label
+{
+	name			"Default"
+	rect			337 94 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/reflect_lightning
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			337 349 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/reflect_2.tga
+	allowactivate	false
+}
+
+resource
+Alice3D
+{
+	name			"alice3d"
+	rect			0 0 640 480
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	allowactivate	false
+}
+
+// Background
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	0 ui/control/controlA
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	1 ui/control/controlB
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 0 128 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	2 ui/control/controlC
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			0 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	3 ui/control/controlD
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	4 ui/control/controlE
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 256 128 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	5 ui/control/controlF
+	allowactivate	false
+}
+
+// bulb
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/bulb_glow
+	allowactivate	false
+}
+
+// glowing heart
+resource
+Label
+{
+	name			"Default"
+	rect			445 22 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/glowing_heart
+	allowactivate	false
+}
+
+// glowing eyes overlay
+resource
+Label
+{
+	name			"Default"
+	rect			454 403 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	font			"asrafel"
+	fontjustify		left center
+	shader			ui/control/skull_glow
+	allowactivate	false
+}
+
+// --------------------------------------
+// --------------------------------------
+// MAIN GROUP
+// --------------------------------------
+// --------------------------------------
+
+// RETURN BUTTON
+resource
+Button
+{
+	title			"Volver"
+	name			"Default"
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu\n"
+	groupid			"group_main"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			28 5
+	fontscale		0.8
+	direction		from_bottom 0.5
+	allowactivate	false
+}
+
+// head
+resource
+Label
+{
+	name			"Default"
+	rect			48 63 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	6 ui/control/head_1
+	groupid			"group_main"
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"TitleBar"
+	rect			48 319 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/head_2
+	groupid			"group_main"
+	
+	allowactivate	false
+} 
+resource
+Label
+{
+	name			"Default"
+	rect			50 330 24 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"ui/control/hslider_prev"
+	groupid			"group_main"
+	allowactivate	false
+} 
+resource
+Label
+{
+	name			"Default"
+	rect			280 330 24 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"ui/control/hslider_next"
+	groupid			"group_main"
+	allowactivate	false
+} 
+// hotspots
+resource
+Button
+{
+	name			"Default"
+	rect			134 143 37 39
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		2
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_video\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_video\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			172 125 56 68
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		3
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_audio\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_audio\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			213 181 50 58
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		4
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_control\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_control_pc\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			138 94 32 39
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		1
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_game\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_game\n"
+	groupid			"group_main"
+}
+
+resource
+Label
+{
+	name			"Default"
+	rect			121 83 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/game_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			120 134 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/video_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			166 129 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/audio_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			210 172 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/control_options
+	noinput
+	allowactivate	false
+}
+
+// --------------------------------------
+// --------------------------------------
+// CONTROL GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Volver"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			37 8
+	ordernumber		6
+}
+
+// RESET BUTTON
+resource
+Button
+{
+	title			"Reiniciar"
+	name			"Default"
+	rect			170 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"exec default_pc.cfg; vid_restart; popmenu 0\n"
+	groupid			"group_control_pc"
+	fontscale		0.8
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			33 10
+	ordernumber		7
+}
+
+// JOYSTICK
+resource
+Button
+{
+	title			"Mando"
+	name			"Default"
+	rect			290 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		34
+}
+
+// BIND LIST
+resource
+FakkBindList
+{
+	title			"BindList"
+	name			"BindList"
+	rect			62 70 230 300
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"3D_BORDER"
+	filename		ui/bind.scr
+	font			"asrafel"
+	groupid			"group_control_pc"
+	ordernumber		5
+}
+
+// APPLY BUTTON
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 640 480
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"controls_pc"
+	groupid			"group_control"
+}
+resource
+Label
+{
+	title			"Ataque secundario /"
+	name			"Default"
+	rect			0 140 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Trepar"
+	name			"Default"
+	rect			0 155 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Arma siguiente"
+	name			"Default"
+	rect			0 175 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Moverse"
+	name			"Default"
+	rect			0 270 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Desplazarse por el menú"
+	name			"Default"
+	rect			120 376 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Girar / Apuntar"
+	name			"Default"
+	rect			350 376 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Atacar / Descender"
+	name			"Default"
+	rect			467 290 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Saltar /"
+	name			"Default"
+	rect			467 259 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nadar hacia arriba"
+	name			"Default"
+	rect			467 274 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Usar /"
+	name			"Default"
+	rect			467 228 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Nadar hacia abajo"
+	name			"Default"
+	rect			467 243 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Ataque secundario /"
+	name			"Default"
+	rect			467 198 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Trepar"
+	name			"Default"
+	rect			467 213 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Arma anterior"
+	name			"Default"
+	rect			467 175 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Atacar / Descender"
+	name			"Default"
+	rect			467 140 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Pausa / Salir del menú"
+	name			"Default"
+	rect			270 110 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		center center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Controles"
+	name			"Default"
+	rect			50 50 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left center
+	fontscale		2.0
+	dropshadow		1
+}
+resource
+Button
+{
+	title			"Atrás"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/plaque
+	hovershader		ui/buttons/plaque_hover
+	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_control_pc\n"
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		35
+} 
+// --------------------------------------
+// --------------------------------------
+// VIDEO GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Aplicar"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_video; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_video"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		15
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Cancelar"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_video; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_video"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		16
+}
+
+// RESOLUTION
+resource
+Label
+{
+	title			"Resolución"
+	name			"ResolutionTxt"
+	rect			68 78 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 94 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+	
+
+	highlighttextwidget "ResolutionTxt"
+	ordernumber		8
+
+	linkcvar		"r_mode"
+}
+
+// COLOR DEPTH
+resource
+Label
+{
+	title			"Colores"
+	name			"ColorTxt"
+	rect			68 118 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 134 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+
+	highlighttextwidget "ColorTxt"
+	ordernumber		9
+
+	linkcvar		"r_colorbits"
+	additem			16 16Bit
+	additem			32 32Bit
+	
+}
+
+// FULLSCREEN
+resource
+Label
+{
+	title			"Pantalla completa"
+	name			"FullscreenTxt"
+	rect			68 158 210 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 158 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"r_fullscreen"
+
+	highlighttextwidget "FullscreenTxt"
+	ordernumber		10
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+	
+}
+
+// BRIGHTNESS
+resource
+Label
+{
+	title			"Brillo"
+	name			"Brightness"
+	rect			68 188 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 204 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	linkcvar		"r_gamma"
+	slidertype		float
+	setrange		.5 1.5
+	stepsize		.05
+	font			"asrafel"
+	
+
+	highlighttextwidget "Brightness"
+	ordernumber		11
+}
+
+// TEXTURE DETAIL
+resource
+Label
+{
+	title			"Detalle de texturas"
+	name			"Texture_Detail"
+	rect			68 238 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 254 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	linkcvar		"r_picmip"
+	slidertype		integer
+	setrange		3 0
+	stepsize		-1
+	font			"asrafel"
+	
+
+	highlighttextwidget "Texture_Detail"
+	ordernumber		12
+}
+
+// TEXTURE DEPTH
+resource
+Label
+{
+	title			"Bits de textura"
+	name			"Texture_Bits"
+	rect			68 278 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 294 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"r_texturebits"
+	additem			16 16Bit
+	additem			32 32Bit
+	
+
+	highlighttextwidget "Texture_Bits"
+	ordernumber		13
+}
+
+// DETAIL TEXTURES
+resource
+Label
+{
+	title			"Texturas de detalle"
+	name			"DetailTxt"
+	rect			68 338 210 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 334 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"r_detailtextures"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+	
+
+	highlighttextwidget "DetailTxt"
+	ordernumber		14
+}
+
+// --------------------------------------
+// --------------------------------------
+// AUDIO GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Aplicar"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_audio; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_audio"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		23
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Cancelar"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_audio; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_audio"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		24
+}
+
+// SOUND DRIVER
+resource
+Label
+{
+	title			"Controlador de sonido"
+	name			"DriverTxt"
+	rect			68 78 200 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 94 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_milesdriver"
+	additem			miles
+	additem			dolby
+	additem			a3d
+	additem			a3d2
+	additem			eax
+	additem			eax2
+
+	highlighttextwidget "DriverTxt"
+	ordernumber		17
+}
+
+// MUSIC VOLUME
+resource
+Label
+{
+	title			"Volumen de música"
+	name			"Music_Volume"
+	rect			68 168 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 184 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	linkcvar		"s_musicvolume"
+	slidertype		float
+	setrange		0 1
+	stepsize		.05
+	font			"asrafel"
+
+	highlighttextwidget "Music_Volume"
+	ordernumber		19
+}
+
+// SFX VOLUME
+resource
+Label
+{
+	title			"Volumen efectos de sonido"
+	name			"SFX_Volume"
+	rect			68 208 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 224 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	linkcvar		"s_volume"
+	slidertype		float
+	setrange		0 1
+	stepsize		.05
+	font			"asrafel"
+
+	highlighttextwidget "SFX_Volume"
+	ordernumber		20
+}
+
+// SPEAKER TYPE
+resource
+Label
+{
+	title			"Tipo de altavoz"
+	name			"SpeakerTxt"
+	rect			68 118 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 134 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_speaker_type"
+	additem			0 "Normal"
+	additem			1 "Auriculares"
+	additem			3 "Sonido envolvente"
+	additem			4 "Altavoces 4 posiciones"
+
+	highlighttextwidget "SpeakerTxt"
+	ordernumber		18
+}
+
+// QUALITY
+resource
+Label
+{
+	title			"Calidad"
+	name			"QualityTxt"
+	rect			68 258 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 274 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_khz"
+	additem			22 "22 khz"
+	additem			44 "44 khz"
+
+	highlighttextwidget "QualityTxt"
+	ordernumber		21
+
+}
+
+// FORCE 8BIT
+resource
+Label
+{
+	title			"Forzar a 8 bit"
+	name			"8BitsTxt"
+	rect			68 298 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 298 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"s_loadas8bit"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	highlighttextwidget "8BitsTxt"
+	ordernumber		22
+}
+
+// --------------------------------------
+// --------------------------------------
+// GAME OPTIONS GROUP
+// --------------------------------------
+// --------------------------------------
+
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Aplicar"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_game; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_game"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		32
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Cancelar"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_game; toggleconsole; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_game"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		33
+}
+
+// SENSITIVITY
+resource
+Label
+{
+	title			"Sensibilidad"
+	name			"Mouse_Sensitivity"
+	rect			68 80 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+	fontspacing		0.5
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 100 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	linkcvar		"sensitivity"
+	setrange		1 20
+	slidertype		float
+	stepsize		1
+	font			"asrafel"
+
+	highlighttextwidget "Mouse_Sensitivity"
+	ordernumber		25
+}
+
+// INVERT MOUSE
+resource
+Label
+{
+	title			"Invertir ratón"
+	name			"InvertMouseTxt"
+	rect			68 130 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 130 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"m_invert_pitch"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	checked_command		"set m_pitch -0.022"
+	unchecked_command	"set m_pitch 0.022"
+
+	highlighttextwidget "InvertMouseTxt"
+	ordernumber		26
+
+}
+
+// CAMERA DISTANCE
+resource
+Label
+{
+	title			"Cámara a distancia"
+	name			"Camera_Distance"
+	rect			68 158 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	rect			88 178 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	linkcvar		"cg_cameradist"
+	slidertype		float
+	setrange		76 192
+	stepsize		4
+	font			"asrafel"
+
+	highlighttextwidget "Camera_Distance"
+	ordernumber		27
+
+}
+
+// ALWAYS RUN
+resource
+Label
+{
+	title			"Correr siempre"
+	name			"AlwaysRunTxt"
+	rect			68 210 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 210 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"cl_run"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "AlwaysRunTxt"
+	ordernumber		28
+
+}
+
+// JUMP RETICLE
+resource
+Label
+{
+	title			"Retícula de salto"
+	name			"JumpReticleTxt"
+	rect			68 270 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 270 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_jumpreticle"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "JumpReticleTxt"
+	ordernumber		29
+}
+
+// TARGET RETICLE
+resource
+Label
+{
+	title			"Retícula de objetivo"
+	name			"TargetReticleTxt"
+	rect			68 290 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 290 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_crosshair"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "TargetReticleTxt"
+	ordernumber		30
+}
+
+// SUBTITLES
+resource
+Label
+{
+	title			"Subtítulos"
+	name			"SubtitlesTxt"
+	rect			68 330 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 330 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_subtitles"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "SubtitlesTxt"
+	ordernumber		31
+}
+
+end.
+ÍÂ¬

--- a/assets/pak6_VorpalFix/controls_pc_fra.urc
+++ b/assets/pak6_VorpalFix/controls_pc_fra.urc
@@ -1,0 +1,1498 @@
+menu "controls" 640 480 NONE 0.5
+fadeoverlay 0.5
+bgcolor 0 0 0 1
+borderstyle NONE
+bgfill 0 0 0 1
+fullscreen 1
+// vidmode 3
+
+showcommand "widgetcommand TitleBar activategroup group_main\n"
+showcommand "widgetcommand alice3d setanim idle_stand_rocktoes\n"
+
+allowactivate	true
+keycommand		1 "widgetcommand TitleBar activategroup group_video\n"
+keycommand		2 "widgetcommand TitleBar activategroup group_audio\n"
+keycommand		3 "widgetcommand TitleBar activategroup group_control_pc\n"
+keycommand		4 "widgetcommand TitleBar activategroup group_game\n"
+
+// Mirror background
+resource
+Label
+{
+	name			"Default"
+	rect			337 94 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/reflect_lightning
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			337 349 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/reflect_2.tga
+	allowactivate	false
+}
+
+resource
+Alice3D
+{
+	name			"alice3d"
+	rect			0 0 640 480
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	allowactivate	false
+}
+
+// Background
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	0 ui/control/controlA
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	1 ui/control/controlB
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 0 128 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	2 ui/control/controlC
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			0 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	3 ui/control/controlD
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	4 ui/control/controlE
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 256 128 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	5 ui/control/controlF
+	allowactivate	false
+}
+
+// bulb
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/bulb_glow
+	allowactivate	false
+}
+
+// glowing heart
+resource
+Label
+{
+	name			"Default"
+	rect			445 22 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/glowing_heart
+	allowactivate	false
+}
+
+// glowing eyes overlay
+resource
+Label
+{
+	name			"Default"
+	rect			454 403 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	font			"asrafel"
+	fontjustify		left center
+	shader			ui/control/skull_glow
+	allowactivate	false
+}
+
+// --------------------------------------
+// --------------------------------------
+// MAIN GROUP
+// --------------------------------------
+// --------------------------------------
+
+// RETURN BUTTON
+resource
+Button
+{
+	title			"Retour"
+	name			"Default"
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu\n"
+	groupid			"group_main"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
+	allowactivate	false
+}
+
+// head
+resource
+Label
+{
+	name			"Default"
+	rect			48 63 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	6 ui/control/head_1
+	groupid			"group_main"
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"TitleBar"
+	rect			48 319 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/head_2
+	groupid			"group_main"
+	
+	allowactivate	false
+} 
+resource
+Label
+{
+	name			"Default"
+	rect			75 330 24 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"ui/control/hslider_prev"
+	groupid			"group_main"
+	allowactivate	false
+} 
+resource
+Label
+{
+	name			"Default"
+	rect			257 330 24 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"ui/control/hslider_next"
+	groupid			"group_main"
+	allowactivate	false
+} 
+// hotspots
+resource
+Button
+{
+	name			"Default"
+	rect			134 143 37 39
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		2
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_video\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_video\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			172 125 56 68
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		3
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_audio\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_audio\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			213 181 50 58
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		4
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_control\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_control_pc\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			138 94 32 39
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		1
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_game\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_game\n"
+	groupid			"group_main"
+}
+
+resource
+Label
+{
+	name			"Default"
+	rect			121 83 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/game_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			120 134 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/video_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			166 129 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/audio_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			210 172 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/control_options
+	noinput
+	allowactivate	false
+}
+
+// --------------------------------------
+// --------------------------------------
+// CONTROL GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Retour"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			37 8
+	ordernumber		6
+}
+
+// RESET BUTTON
+resource
+Button
+{
+	title			"Rétablir"
+	name			"Default"
+	rect			170 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"exec default_pc_fra.cfg; vid_restart; popmenu 0\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			33 8
+	ordernumber		7
+}
+
+// JOYSTICK
+resource
+Button
+{
+	title			"Manette"
+	name			"Default"
+	rect			290 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		34
+}
+
+// BIND LIST
+resource
+FakkBindList
+{
+	title			"BindList"
+	name			"BindList"
+	rect			62 70 230 300
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"3D_BORDER"
+	filename		ui/bind.scr
+	font			"asrafel"
+	groupid			"group_control_pc"
+	ordernumber		5
+}
+
+// APPLY BUTTON
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 640 480
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"controls_pc"
+	groupid			"group_control"
+}
+resource
+Label
+{
+	title			"Attaque alternative /"
+	name			"Default"
+	rect			0 140 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Grimper"
+	name			"Default"
+	rect			0 155 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Arme suivante"
+	name			"Default"
+	rect			0 175 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Déplacement"
+	name			"Default"
+	rect			0 270 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Navigation"
+	name			"Default"
+	rect			120 376 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Tourner/Viser"
+	name			"Default"
+	rect			350 376 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Attaquer / Descendre"
+	name			"Default"
+	rect			467 290 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Sauter / Remonter"
+	name			"Default"
+	rect			467 260 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Utiliser / Plonger"
+	name			"Default"
+	rect			467 230 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Attaque alternative /"
+	name			"Default"
+	rect			467 202 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Grimper"
+	name			"Default"
+	rect			467 217 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Arme précédente"
+	name			"Default"
+	rect			467 175 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Attaquer / Descendre"
+	name			"Default"
+	rect			467 140 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Menu Pause/Quitter"
+	name			"Default"
+	rect			270 110 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		center center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Commandes"
+	name			"Default"
+	rect			50 50 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left center
+	fontscale		2.0
+	dropshadow		1
+}
+resource
+Button
+{
+	title			"Retour"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/plaque
+	hovershader		ui/buttons/plaque_hover
+	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_control_pc\n"
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		35
+} 
+// --------------------------------------
+// --------------------------------------
+// VIDEO GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Appliquer"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_video; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_video"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		15
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Annuler"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_video; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_video"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		16
+}
+
+// RESOLUTION
+resource
+Label
+{
+	title			"Résolution"
+	name			"ResolutionTxt"
+	rect			68 78 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 94 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+	
+
+	highlighttextwidget "ResolutionTxt"
+	ordernumber		8
+
+	linkcvar		"r_mode"
+}
+
+// COLOR DEPTH
+resource
+Label
+{
+	title			"Couleurs"
+	name			"ColorTxt"
+	rect			68 118 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 134 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+
+	highlighttextwidget "ColorTxt"
+	ordernumber		9
+
+	linkcvar		"r_colorbits"
+	additem			16 16Bit
+	additem			32 32Bit
+	
+}
+
+// FULLSCREEN
+resource
+Label
+{
+	title			"Plein écran"
+	name			"FullscreenTxt"
+	rect			68 158 210 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 158 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"r_fullscreen"
+
+	highlighttextwidget "FullscreenTxt"
+	ordernumber		10
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+	
+}
+
+// BRIGHTNESS
+resource
+Label
+{
+	title			"Luminosité"
+	name			"Brightness"
+	rect			68 188 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 204 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	linkcvar		"r_gamma"
+	slidertype		float
+	setrange		.5 1.5
+	stepsize		.05
+	font			"asrafel"
+	
+
+	highlighttextwidget "Brightness"
+	ordernumber		11
+}
+
+// TEXTURE DETAIL
+resource
+Label
+{
+	title			"Détail des textures"
+	name			"Texture_Detail"
+	rect			68 238 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 254 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	linkcvar		"r_picmip"
+	slidertype		integer
+	setrange		3 0
+	stepsize		-1
+	font			"asrafel"
+	
+
+	highlighttextwidget "Texture_Detail"
+	ordernumber		12
+}
+
+// TEXTURE DEPTH
+resource
+Label
+{
+	title			"Bits textures"
+	name			"Texture_Bits"
+	rect			68 278 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 294 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"r_texturebits"
+	additem			16 16Bit
+	additem			32 32Bit
+	
+
+	highlighttextwidget "Texture_Bits"
+	ordernumber		13
+}
+
+// DETAIL TEXTURES
+resource
+Label
+{
+	title			"Textures des détails"
+	name			"DetailTxt"
+	rect			68 338 210 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 334 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"r_detailtextures"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+	
+
+	highlighttextwidget "DetailTxt"
+	ordernumber		14
+}
+
+// --------------------------------------
+// --------------------------------------
+// AUDIO GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Appliquer"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_audio; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_audio"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		23
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Annuler"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_audio; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_audio"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		24
+}
+
+// SOUND DRIVER
+resource
+Label
+{
+	title			"Pilote son"
+	name			"DriverTxt"
+	rect			68 78 200 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 94 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_milesdriver"
+	additem			miles
+	additem			dolby
+	additem			a3d
+	additem			a3d2
+	additem			eax
+	additem			eax2
+
+	highlighttextwidget "DriverTxt"
+	ordernumber		17
+}
+
+// MUSIC VOLUME
+resource
+Label
+{
+	title			"Volume musique"
+	name			"Music_Volume"
+	rect			68 168 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 184 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	linkcvar		"s_musicvolume"
+	slidertype		float
+	setrange		0 1
+	stepsize		.05
+	font			"asrafel"
+
+	highlighttextwidget "Music_Volume"
+	ordernumber		19
+}
+
+// SFX VOLUME
+resource
+Label
+{
+	title			"Volume effets sonores"
+	name			"SFX_Volume"
+	rect			68 208 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 224 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	linkcvar		"s_volume"
+	slidertype		float
+	setrange		0 1
+	stepsize		.05
+	font			"asrafel"
+
+	highlighttextwidget "SFX_Volume"
+	ordernumber		20
+}
+
+// SPEAKER TYPE
+resource
+Label
+{
+	title			"Type haut-parleur"
+	name			"SpeakerTxt"
+	rect			68 118 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 134 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_speaker_type"
+	additem			0 "Normal"
+	additem			1 "Casque"
+	additem			3 "Son Surround"
+	additem			4 "4 haut-parleurs"
+
+	highlighttextwidget "SpeakerTxt"
+	ordernumber		18
+}
+
+// QUALITY
+resource
+Label
+{
+	title			"Qualité"
+	name			"QualityTxt"
+	rect			68 258 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 274 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_khz"
+	additem			22 "22 khz"
+	additem			44 "44 khz"
+
+	highlighttextwidget "QualityTxt"
+	ordernumber		21
+
+}
+
+// FORCE 8BIT
+resource
+Label
+{
+	title			"Son 8 bits"
+	name			"8BitsTxt"
+	rect			68 298 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 298 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"s_loadas8bit"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	highlighttextwidget "8BitsTxt"
+	ordernumber		22
+}
+
+// --------------------------------------
+// --------------------------------------
+// GAME OPTIONS GROUP
+// --------------------------------------
+// --------------------------------------
+
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Appliquer"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_game; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_game"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		32
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Annuler"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_game; toggleconsole; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_game"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			30 8
+	fontscale		0.8
+	ordernumber		33
+}
+
+// SENSITIVITY
+resource
+Label
+{
+	title			"Sensibilité"
+	name			"Mouse_Sensitivity"
+	rect			68 80 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+	fontspacing		0.5
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 100 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	linkcvar		"sensitivity"
+	setrange		1 20
+	slidertype		float
+	stepsize		1
+	font			"asrafel"
+
+	highlighttextwidget "Mouse_Sensitivity"
+	ordernumber		25
+}
+
+// INVERT MOUSE
+resource
+Label
+{
+	title			"Inverser souris"
+	name			"InvertMouseTxt"
+	rect			68 130 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 130 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"m_invert_pitch"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	checked_command		"set m_pitch -0.022"
+	unchecked_command	"set m_pitch 0.022"
+
+	highlighttextwidget "InvertMouseTxt"
+	ordernumber		26
+
+}
+
+// CAMERA DISTANCE
+resource
+Label
+{
+	title			"Distance caméra"
+	name			"Camera_Distance"
+	rect			68 158 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	rect			88 178 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	linkcvar		"cg_cameradist"
+	slidertype		float
+	setrange		76 192
+	stepsize		4
+	font			"asrafel"
+
+	highlighttextwidget "Camera_Distance"
+	ordernumber		27
+
+}
+
+// ALWAYS RUN
+resource
+Label
+{
+	title			"Course permanente"
+	name			"AlwaysRunTxt"
+	rect			68 210 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 210 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"cl_run"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "AlwaysRunTxt"
+	ordernumber		28
+
+}
+
+// JUMP RETICLE
+resource
+Label
+{
+	title			"Réticule de saut"
+	name			"JumpReticleTxt"
+	rect			68 270 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 270 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_jumpreticle"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "JumpReticleTxt"
+	ordernumber		29
+}
+
+// TARGET RETICLE
+resource
+Label
+{
+	title			"Réticule de la cible"
+	name			"TargetReticleTxt"
+	rect			68 290 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 290 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_crosshair"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "TargetReticleTxt"
+	ordernumber		30
+}
+
+// SUBTITLES
+resource
+Label
+{
+	title			"Sous-titrage"
+	name			"SubtitlesTxt"
+	rect			68 330 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 330 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_subtitles"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "SubtitlesTxt"
+	ordernumber		31
+}
+
+end.
+ÍÍÍÂ¬

--- a/assets/pak6_VorpalFix/controls_pc_int.urc
+++ b/assets/pak6_VorpalFix/controls_pc_int.urc
@@ -1,0 +1,1461 @@
+menu "controls" 640 480 NONE 0.5
+fadeoverlay 0.5
+bgcolor 0 0 0 1
+borderstyle NONE
+bgfill 0 0 0 1
+fullscreen 1
+// vidmode 3
+
+showcommand "widgetcommand TitleBar activategroup group_main\n"
+showcommand "widgetcommand alice3d setanim idle_stand_rocktoes\n"
+
+allowactivate	true
+keycommand		1 "widgetcommand TitleBar activategroup group_video\n"
+keycommand		2 "widgetcommand TitleBar activategroup group_audio\n"
+keycommand		3 "widgetcommand TitleBar activategroup group_control_pc\n"
+keycommand		4 "widgetcommand TitleBar activategroup group_game\n"
+
+// Mirror background
+resource
+Label
+{
+	name			"Default"
+	rect			337 94 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/reflect_lightning
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			337 349 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/reflect_2
+	allowactivate	false
+}
+
+resource
+Alice3D
+{
+	name			"alice3d"
+	rect			0 0 640 480
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	allowactivate	false
+}
+
+// Background
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	0 ui/control/controlA
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	1 ui/control/controlB
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 0 128 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	2 ui/control/controlC
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			0 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	3 ui/control/controlD
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	4 ui/control/controlE
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 256 128 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	5 ui/control/controlF
+	allowactivate	false
+}
+
+// bulb
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/bulb_glow
+	allowactivate	false
+}
+
+// glowing heart
+resource
+Label
+{
+	name			"Default"
+	rect			445 22 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/glowing_heart
+	allowactivate	false
+}
+
+// glowing eyes overlay
+resource
+Label
+{
+	name			"Default"
+	rect			454 403 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	font			"asrafel"
+	fontjustify		left center
+	shader			ui/control/skull_glow
+	allowactivate	false
+}
+
+// --------------------------------------
+// --------------------------------------
+// MAIN GROUP
+// --------------------------------------
+// --------------------------------------
+
+// RETURN BUTTON
+resource
+Button
+{
+	name			"Default"
+	rect			0 456 80 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/back_button
+	hovershader		ui/back_button_hover
+	stuffcommand	"popmenu"
+	allowactivate	false
+	groupid			"group_main"
+	allowactivate	false
+}
+
+// head
+resource
+Label
+{
+	name			"Default"
+	rect			48 63 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	6 ui/control/head_1
+	groupid			"group_main"
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"TitleBar"
+	rect			48 319 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/control/head_2
+	groupid			"group_main"
+	
+	allowactivate	false
+} 
+resource
+Label
+{
+	name			"Default"
+	rect			75 330 24 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"ui/control/hslider_prev"
+	groupid			"group_main"
+	allowactivate	false
+} 
+resource
+Label
+{
+	name			"Default"
+	rect			257 330 24 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"ui/control/hslider_next"
+	groupid			"group_main"
+	allowactivate	false
+} 
+// hotspots
+resource
+Button
+{
+	name			"Default"
+	rect			134 143 37 39
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		2
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_video\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_video\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			172 125 56 68
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		3
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_audio\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_audio\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			213 181 50 58
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		4
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_control\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_control_pc\n"
+	groupid			"group_main"
+}
+resource
+Button
+{
+	name			"Default"
+	rect			138 94 32 39
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	ordernumber		1
+	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_game\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_game\n"
+	groupid			"group_main"
+}
+
+resource
+Label
+{
+	name			"Default"
+	rect			121 83 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/game_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			120 134 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/video_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			166 129 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/audio_options
+	noinput
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			210 172 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_main"
+	shader			ui/control/control_options
+	noinput
+	allowactivate	false
+}
+
+// --------------------------------------
+// --------------------------------------
+// CONTROL GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Back"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		6
+}
+
+// RESET BUTTON
+resource
+Button
+{
+	title			"Reset"
+	name			"Default"
+	rect			170 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"exec default_pc.cfg; vid_restart; popmenu 0\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		7
+}
+
+// JOYSTICK
+resource
+Button
+{
+	title			"Controller"
+	name			"Default"
+	rect			290 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/plaque
+	hovershader		ui/buttons/plaque_hover
+	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
+	groupid			"group_control_pc"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			13 8
+	fontscale		0.8	
+	ordernumber		34
+}
+
+// BIND LIST
+resource
+FakkBindList
+{
+	title			"BindList"
+	name			"BindList"
+	rect			62 70 230 300
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"3D_BORDER"
+	filename		bind_pc.scr
+	font			"asrafel"
+	groupid			"group_control_pc"
+	ordernumber		5
+}
+
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 640 480
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			"controls_pc"
+	groupid			"group_control"
+}
+resource
+Label
+{
+	title			"Alt Attack / Climb Up"
+	name			"Default"
+	rect			0 140 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Next Weapon"
+	name			"Default"
+	rect			0 175 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Move"
+	name			"Default"
+	rect			0 270 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Menu Navigation"
+	name			"Default"
+	rect			120 376 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		right center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Turn / Aim"
+	name			"Default"
+	rect			350 376 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Attack / Climb Down"
+	name			"Default"
+	rect			467 290 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Jump / Swim Up"
+	name			"Default"
+	rect			467 260 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Use / Swim Down"
+	name			"Default"
+	rect			467 230 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Alt Attack / Climb Up"
+	name			"Default"
+	rect			467 202 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Prev Weapon"
+	name			"Default"
+	rect			467 175 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Attack / Climb Down"
+	name			"Default"
+	rect			467 140 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left top
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Pause / Exit Menu"
+	name			"Default"
+	rect			270 110 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		center center
+	fontscale		0.8
+}
+resource
+Label
+{
+	title			"Controls"
+	name			"Default"
+	rect			50 50 167 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		left center
+	fontscale		2.0
+	dropshadow		1
+}
+resource
+Button
+{
+	title			"Back"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/plaque
+	hovershader		ui/buttons/plaque_hover
+	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_control_pc\n"
+	groupid			"group_control"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		35
+} 
+// --------------------------------------
+// --------------------------------------
+// VIDEO GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Apply"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_video; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_video"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		15
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Cancel"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_video; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_video"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		16
+}
+
+// RESOLUTION
+resource
+Label
+{
+	title			"Resolution"
+	name			"ResolutionTxt"
+	rect			68 78 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 94 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+	
+
+	highlighttextwidget "ResolutionTxt"
+	ordernumber		8
+
+	linkcvar		"r_mode"
+}
+
+// COLOR DEPTH
+resource
+Label
+{
+	title			"Color Depth"
+	name			"ColorTxt"
+	rect			68 118 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 134 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+
+	highlighttextwidget "ColorTxt"
+	ordernumber		9
+
+	linkcvar		"r_colorbits"
+	additem			16 16Bit
+	additem			32 32Bit
+	
+}
+
+// FULLSCREEN
+resource
+Label
+{
+	title			"Fullscreen"
+	name			"FullscreenTxt"
+	rect			68 158 210 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 158 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"r_fullscreen"
+
+	highlighttextwidget "FullscreenTxt"
+	ordernumber		10
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+	
+}
+
+// BRIGHTNESS
+resource
+Label
+{
+	title			"Brightness"
+	name			"Brightness"
+	rect			68 188 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 204 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	linkcvar		"r_gamma"
+	slidertype		float
+	setrange		.5 1.5
+	stepsize		.05
+	font			"asrafel"
+	
+
+	highlighttextwidget "Brightness"
+	ordernumber		11
+}
+
+// TEXTURE DETAIL
+resource
+Label
+{
+	title			"Texture Detail"
+	name			"Texture_Detail"
+	rect			68 238 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 254 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	linkcvar		"r_picmip"
+	slidertype		integer
+	setrange		3 0
+	stepsize		-1
+	font			"asrafel"
+	
+
+	highlighttextwidget "Texture_Detail"
+	ordernumber		12
+}
+
+// TEXTURE DEPTH
+resource
+Label
+{
+	title			"Texture Depth"
+	name			"Texture_Bits"
+	rect			68 278 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 294 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"r_texturebits"
+	additem			16 16Bit
+	additem			32 32Bit
+	
+
+	highlighttextwidget "Texture_Bits"
+	ordernumber		13
+}
+
+// DETAIL TEXTURES
+resource
+Label
+{
+	title			"Detail Textures"
+	name			"DetailTxt"
+	rect			68 338 210 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		left center
+	
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 334 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_video"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"r_detailtextures"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+	
+
+	highlighttextwidget "DetailTxt"
+	ordernumber		14
+}
+
+// --------------------------------------
+// --------------------------------------
+// AUDIO GROUP
+// --------------------------------------
+// --------------------------------------
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Apply"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_audio; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_audio"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		23
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Cancel"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_audio; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_audio"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		24
+}
+
+// SOUND DRIVER
+resource
+Label
+{
+	title			"Sound Driver"
+	name			"DriverTxt"
+	rect			68 78 200 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 94 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_milesdriver"
+	additem			miles
+	additem			dolby
+	additem			a3d
+	additem			a3d2
+	additem			eax
+	additem			eax2
+
+	highlighttextwidget "DriverTxt"
+	ordernumber		17
+}
+
+// MUSIC VOLUME
+resource
+Label
+{
+	title			"Music Volume"
+	name			"Music_Volume"
+	rect			68 168 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 184 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	linkcvar		"s_musicvolume"
+	slidertype		float
+	setrange		0 1
+	stepsize		.05
+	font			"asrafel"
+
+	highlighttextwidget "Music_Volume"
+	ordernumber		19
+}
+
+// SFX VOLUME
+resource
+Label
+{
+	title			"Effects Volume"
+	name			"SFX_Volume"
+	rect			68 208 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 224 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	linkcvar		"s_volume"
+	slidertype		float
+	setrange		0 1
+	stepsize		.05
+	font			"asrafel"
+
+	highlighttextwidget "SFX_Volume"
+	ordernumber		20
+}
+
+// SPEAKER TYPE
+resource
+Label
+{
+	title			"Speaker Type"
+	name			"SpeakerTxt"
+	rect			68 118 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 134 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_speaker_type"
+	additem			0 "Normal"
+	additem			1 "Headphones"
+	additem			3 "Surround"
+	additem			4 "Quad"
+
+	highlighttextwidget "SpeakerTxt"
+	ordernumber		18
+}
+
+// QUALITY
+resource
+Label
+{
+	title			"Quality"
+	name			"QualityTxt"
+	rect			68 258 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+List
+{
+	name			"Default"
+	rect			88 274 200 20
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		center top
+
+	linkcvar		"s_khz"
+	additem			22 "22 khz"
+	additem			44 "44 khz"
+
+	highlighttextwidget "QualityTxt"
+	ordernumber		21
+
+}
+
+// FORCE 8BIT
+resource
+Label
+{
+	title			"Force 8bits"
+	name			"8BitsTxt"
+	rect			68 298 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 298 16 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_audio"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"s_loadas8bit"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	highlighttextwidget "8BitsTxt"
+	ordernumber		22
+}
+
+// --------------------------------------
+// --------------------------------------
+// GAME OPTIONS GROUP
+// --------------------------------------
+// --------------------------------------
+
+
+// APPLY BUTTON
+resource
+Button
+{
+	title			"Apply"
+	name			"Default"
+	rect			50 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_setcvars group_game; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_game"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		32
+}
+
+// CANCEL BUTTON
+resource
+Button
+{
+	title			"Cancel"
+	name			"Default"
+	rect			200 400 100 35
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/apply
+	hovershader		ui/buttons/apply_hover
+	stuffcommand	"ui_restorecvars group_game; toggleconsole; widgetcommand TitleBar activategroup group_main\n"
+	groupid			"group_game"
+	
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			35 8
+	ordernumber		33
+}
+
+// SENSITIVITY
+resource
+Label
+{
+	title			"Sensitivity"
+	name			"Mouse_Sensitivity"
+	rect			68 80 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+	fontspacing		0.5
+}
+resource
+Slider
+{
+	name			"Default"
+	rect			88 100 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	linkcvar		"sensitivity"
+	setrange		1 20
+	slidertype		float
+	stepsize		1
+	font			"asrafel"
+
+	highlighttextwidget "Mouse_Sensitivity"
+	ordernumber		25
+}
+
+// INVERT MOUSE
+resource
+Label
+{
+	title			"Invert Mouse"
+	name			"InvertMouseTxt"
+	rect			68 130 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 130 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"m_invert_pitch"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	checked_command		"set m_pitch -0.022"
+	unchecked_command	"set m_pitch 0.022"
+
+	highlighttextwidget "InvertMouseTxt"
+	ordernumber		26
+
+}
+
+// CAMERA DISTANCE
+resource
+Label
+{
+	title			"Camera Distance"
+	name			"Camera_Distance"
+	rect			68 158 220 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+Slider
+{
+	rect			88 178 200 16
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	linkcvar		"cg_cameradist"
+	slidertype		float
+	setrange		76 192
+	stepsize		4
+	font			"asrafel"
+
+	highlighttextwidget "Camera_Distance"
+	ordernumber		27
+
+}
+
+// ALWAYS RUN
+resource
+Label
+{
+	title			"Always Run"
+	name			"AlwaysRunTxt"
+	rect			68 210 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	name			"Default"
+	rect			260 210 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"cl_run"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "AlwaysRunTxt"
+	ordernumber		28
+
+}
+
+// JUMP RETICLE
+resource
+Label
+{
+	title			"Jump Reticle"
+	name			"JumpReticleTxt"
+	rect			68 270 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 270 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_jumpreticle"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "JumpReticleTxt"
+	ordernumber		29
+}
+
+// TARGET RETICLE
+resource
+Label
+{
+	title			"Target Reticle"
+	name			"TargetReticleTxt"
+	rect			68 290 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 290 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_crosshair"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "TargetReticleTxt"
+	ordernumber		30
+}
+
+// SUBTITLES
+resource
+Label
+{
+	title			"Subtitles"
+	name			"SubtitlesTxt"
+	rect			68 330 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 330 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_subtitles"
+
+	checked_shader	 "ui/control/checkbox_checked"
+	unchecked_shader "ui/control/checkbox_unchecked"
+
+	highlighttextwidget "SubtitlesTxt"
+	ordernumber		31
+}
+
+end.
+อออยฌ


### PR DESCRIPTION
Hello!

Something that always bothered me is that when you use the left or right key on the Camera Distance option it goes all the way to the right, which was due to the stepsize being -1, this changes it to 4 (I chose that number since the min and max are 76 and 192 therefore 4 fits perfect) so now it moves properly.

(I'll include this fix for the reworked console menus too, specially since there pressing left or right is the only way to change options).