### PR TITLE
Alternative Quit Button Prompts

### DIFF
--- a/assets/pak6_VorpalFix/DEU/quit2.urc
+++ b/assets/pak6_VorpalFix/DEU/quit2.urc
@@ -137,7 +137,7 @@ Button
 {
 	title			"Wechseln"
 	name			"Default"
-	rect			375 385 115 35
+	rect			475 45 115 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -151,7 +151,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			380 390 24 24
+	rect			480 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -163,7 +163,7 @@ Button
 {
 	title			"Auswählen"
 	name			"Default"
-	rect			245 426 130 35
+	rect			325 45 130 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -177,39 +177,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			250 431 24 24
+	rect			330 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			"a_button_xbox"	
-	allowactivate	false
-}
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Zurück"
-	name			"Default"
-	rect			505 385 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			510 390 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/DEU_ps3/quit2.urc
+++ b/assets/pak6_VorpalFix/DEU_ps3/quit2.urc
@@ -137,7 +137,7 @@ Button
 {
 	title			"Wechseln"
 	name			"Default"
-	rect			375 385 115 35
+	rect			475 45 115 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -151,7 +151,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			380 390 24 24
+	rect			480 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -163,7 +163,7 @@ Button
 {
 	title			"Auswählen"
 	name			"Default"
-	rect			245 426 130 35
+	rect			325 45 130 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -177,39 +177,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			250 431 24 24
+	rect			330 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			"cross_button_ps3"	
-	allowactivate	false
-}
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Zurück"
-	name			"Default"
-	rect			505 385 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			510 390 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/ESN/quit2.urc
+++ b/assets/pak6_VorpalFix/ESN/quit2.urc
@@ -137,7 +137,7 @@ Button
 {
 	title			"Cambiar"
 	name			"Default"
-	rect			375 385 100 35
+	rect			490 45 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -151,7 +151,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			380 390 24 24
+	rect			495 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -163,7 +163,7 @@ Button
 {
 	title			"Seleccionar"
 	name			"Default"
-	rect			245 426 130 35
+	rect			340 45 130 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -177,39 +177,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			250 431 24 24
+	rect			345 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			"a_button_xbox"	
-	allowactivate	false
-}
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Atrás"
-	name			"Default"
-	rect			505 385 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			510 390 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/ESN_ps3/quit2.urc
+++ b/assets/pak6_VorpalFix/ESN_ps3/quit2.urc
@@ -137,7 +137,7 @@ Button
 {
 	title			"Cambiar"
 	name			"Default"
-	rect			375 385 100 35
+	rect			490 45 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -151,7 +151,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			380 390 24 24
+	rect			495 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -163,7 +163,7 @@ Button
 {
 	title			"Seleccionar"
 	name			"Default"
-	rect			245 426 130 35
+	rect			340 45 130 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -177,39 +177,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			250 431 24 24
+	rect			345 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			"cross_button_ps3"	
-	allowactivate	false
-}
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Atrás"
-	name			"Default"
-	rect			505 385 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			510 390 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/FRA/quit2.urc
+++ b/assets/pak6_VorpalFix/FRA/quit2.urc
@@ -137,7 +137,7 @@ Button
 {
 	title			"Changer"
 	name			"Default"
-	rect			370 385 100 35
+	rect			490 45 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -151,7 +151,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			375 390 24 24
+	rect			495 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -163,7 +163,7 @@ Button
 {
 	title			"Valider"
 	name			"Default"
-	rect			250 426 100 35
+	rect			340 45 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -177,39 +177,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			255 431 24 24
+	rect			345 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			"a_button_xbox"	
 	allowactivate	false
 } 
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Retour"
-	name			"Default"
-	rect			490 385 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			495 390 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"b_button_xbox"	
-	allowactivate	false
-}
 end.

--- a/assets/pak6_VorpalFix/FRA_ps3/quit2.urc
+++ b/assets/pak6_VorpalFix/FRA_ps3/quit2.urc
@@ -137,7 +137,7 @@ Button
 {
 	title			"Changer"
 	name			"Default"
-	rect			370 385 100 35
+	rect			490 45 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -151,7 +151,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			375 390 24 24
+	rect			495 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -163,7 +163,7 @@ Button
 {
 	title			"Valider"
 	name			"Default"
-	rect			250 426 100 35
+	rect			340 45 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -177,39 +177,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			255 431 24 24
+	rect			345 50 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			"cross_button_ps3"	
 	allowactivate	false
 } 
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Retour"
-	name			"Default"
-	rect			490 385 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			495 390 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
-}
 end.

--- a/assets/pak6_VorpalFix/INT/quit2.urc
+++ b/assets/pak6_VorpalFix/INT/quit2.urc
@@ -137,7 +137,7 @@ Button
 {
 	title			"Change"
 	name			"Default"
-	rect			400 430 100 35
+	rect			490 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -151,7 +151,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			405 435 24 24
+	rect			495 405 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -163,7 +163,7 @@ Button
 {
 	title			"Select"
 	name			"Default"
-	rect			270 430 100 35
+	rect			340 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -177,39 +177,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			275 435 24 24
+	rect			345 405 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			"a_button_xbox"	
-	allowactivate	false
-}
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			530 430 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			535 435 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/INT_ps3/quit2.urc
+++ b/assets/pak6_VorpalFix/INT_ps3/quit2.urc
@@ -137,7 +137,7 @@ Button
 {
 	title			"Change"
 	name			"Default"
-	rect			400 430 100 35
+	rect			490 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -151,7 +151,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			405 435 24 24
+	rect			495 405 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -163,7 +163,7 @@ Button
 {
 	title			"Select"
 	name			"Default"
-	rect			270 430 100 35
+	rect			340 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -177,39 +177,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			275 435 24 24
+	rect			345 405 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			"cross_button_ps3"	
-	allowactivate	false
-}
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			530 430 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			535 435 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
 	allowactivate	false
 }
 end.


### PR DESCRIPTION
Hello there!

I have a little design proposal. I feel like the new button prompts positions in the quit screens looked a little cramped, since I had some free time I've been experimenting and I think I have some new designs that look really nice and on par with the originals.

I took the measures of the original margins for position references and got rid of the "B Back" since is redundant and deleting it in the PC version was already considered at some point. I also made sure to stick them correctly to the right margin using the same logic for design that they used originally for the left.

I made mock ups but you can test them in-game if you want (The missing text is me being lazy on Photoshop).
English:
![quit Moved Button Prompts_INT](https://github.com/user-attachments/assets/4a7ee48c-0cd7-4b17-bde1-fad77f1cb39a)

Other languages:
![quit Moved Button Prompts_DEU](https://github.com/user-attachments/assets/be331f7c-9c50-4e77-94cf-14a838194e29)
![quit Moved Button Prompts_ESN](https://github.com/user-attachments/assets/97548630-dc19-462e-b43a-4a3911ccdddc)
![quit Moved Button Prompts_FRA](https://github.com/user-attachments/assets/0c2f7066-d334-4585-8fc8-d064f2f2e16c)

Hope you like it!