### PR TITLE
Improved Controller Load Screen

### DIFF
--- a/assets/pak6_VorpalFix/DEU/loadsave2.urc
+++ b/assets/pak6_VorpalFix/DEU/loadsave2.urc
@@ -442,7 +442,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
+	shader			"a_button_xbox"	
 	allowactivate	false
 }
 
@@ -471,7 +471,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"square_button_ps3"	
+	shader			"x_button_xbox"	
 	allowactivate	false
 }
 
@@ -500,7 +500,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"tri_button_ps3"	
+	shader			"y_button_xbox"	
 	allowactivate	false
 }
 
@@ -610,7 +610,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/DEU/loadsave2.urc
+++ b/assets/pak6_VorpalFix/DEU/loadsave2.urc
@@ -53,6 +53,17 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+resource
+Label
+{
+	name			"bigcover_black"
+	rect			358 101 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 1.00
+	borderstyle		"NONE"
+	fadein			1.0
+	inversealpha
+}
 
 // LOAD SHOTS
 resource
@@ -244,7 +255,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 2st
@@ -278,7 +289,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 3rd
@@ -312,7 +323,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 4th
@@ -346,7 +357,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 5th
@@ -380,7 +391,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 6th
@@ -414,7 +425,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // LOAD BUTTONS

--- a/assets/pak6_VorpalFix/DEU_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/DEU_ps3/loadsave2.urc
@@ -53,6 +53,17 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+resource
+Label
+{
+	name			"bigcover_black"
+	rect			358 101 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 1.00
+	borderstyle		"NONE"
+	fadein			1.0
+	inversealpha
+}
 
 // LOAD SHOTS
 resource
@@ -244,7 +255,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 2st
@@ -278,7 +289,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 3rd
@@ -312,7 +323,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 4th
@@ -346,7 +357,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 5th
@@ -380,7 +391,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 6th
@@ -414,7 +425,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // LOAD BUTTONS

--- a/assets/pak6_VorpalFix/ESN/loadsave2.urc
+++ b/assets/pak6_VorpalFix/ESN/loadsave2.urc
@@ -421,7 +421,7 @@ Button
 resource
 Button
 {
-	title			"LADEN"
+	title			"CARGAR"
 	name			"LoadingButton"
 	rect			300 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -442,7 +442,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
+	shader			"a_button_xbox"	
 	allowactivate	false
 }
 
@@ -450,7 +450,7 @@ Button
 resource
 Button
 {
-	title			"Speichern"
+	title			"GUARDAR"
 	name			"SaveButton"
 	rect			400 400 110 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -471,7 +471,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"square_button_ps3"	
+	shader			"x_button_xbox"	
 	allowactivate	false
 }
 
@@ -479,7 +479,7 @@ Button
 resource
 Button
 {
-	title			"LÖSCHEN"
+	title			"BORRAR"
 	name			"DeleteButton"
 	rect			510 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -500,7 +500,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"tri_button_ps3"	
+	shader			"y_button_xbox"	
 	allowactivate	false
 }
 
@@ -589,7 +589,7 @@ Label
 resource
 Button
 {
-	title			"Zurück"
+	title			"Atrás"
 	name			"Default"
 	rect			510 355 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -610,7 +610,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/ESN/loadsave2.urc
+++ b/assets/pak6_VorpalFix/ESN/loadsave2.urc
@@ -53,6 +53,17 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+resource
+Label
+{
+	name			"bigcover_black"
+	rect			358 101 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 1.00
+	borderstyle		"NONE"
+	fadein			1.0
+	inversealpha
+}
 
 // LOAD SHOTS
 resource
@@ -244,7 +255,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 2st
@@ -278,7 +289,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 3rd
@@ -312,7 +323,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 4th
@@ -346,7 +357,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 5th
@@ -380,7 +391,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 6th
@@ -414,7 +425,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // LOAD BUTTONS

--- a/assets/pak6_VorpalFix/ESN_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/ESN_ps3/loadsave2.urc
@@ -53,6 +53,17 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+resource
+Label
+{
+	name			"bigcover_black"
+	rect			358 101 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 1.00
+	borderstyle		"NONE"
+	fadein			1.0
+	inversealpha
+}
 
 // LOAD SHOTS
 resource
@@ -244,7 +255,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 2st
@@ -278,7 +289,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 3rd
@@ -312,7 +323,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 4th
@@ -346,7 +357,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 5th
@@ -380,7 +391,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 6th
@@ -414,7 +425,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // LOAD BUTTONS

--- a/assets/pak6_VorpalFix/ESN_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/ESN_ps3/loadsave2.urc
@@ -591,7 +591,7 @@ Button
 {
 	title			"Atrás"
 	name			"Default"
-	rect			100 400 100 35
+	rect			510 355 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -606,7 +606,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			105 405 24 24
+	rect			515 360 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"

--- a/assets/pak6_VorpalFix/FRA/loadsave2.urc
+++ b/assets/pak6_VorpalFix/FRA/loadsave2.urc
@@ -421,9 +421,9 @@ Button
 resource
 Button
 {
-	title			"LADEN"
+	title			"CHARGER"
 	name			"LoadingButton"
-	rect			300 400 100 35
+	rect			295 400 95 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -432,17 +432,17 @@ Button
 	font			"asrafel"
 	fontjustify		center center
 	fontscale		0.8
-	fontpos			35 8
+	fontpos			30 8
 } 
 resource
 Button
 {
 	name			"Default"
-	rect			305 405 24 24
+	rect			300 405 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
+	shader			"a_button_xbox"	
 	allowactivate	false
 }
 
@@ -450,9 +450,9 @@ Button
 resource
 Button
 {
-	title			"Speichern"
+	title			"SAUVEGARDER"
 	name			"SaveButton"
-	rect			400 400 110 35
+	rect			390 400 130 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -461,17 +461,17 @@ Button
 	font			"asrafel"
 	fontjustify		center center
 	fontscale		0.8
-	fontpos			35 8
+	fontpos			30 8
 } 
 resource
 Button
 {
 	name			"Default"
-	rect			405 405 24 24
+	rect			395 405 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"square_button_ps3"	
+	shader			"x_button_xbox"	
 	allowactivate	false
 }
 
@@ -479,9 +479,9 @@ Button
 resource
 Button
 {
-	title			"LÖSCHEN"
+	title			"EFFACER"
 	name			"DeleteButton"
-	rect			510 400 100 35
+	rect			520 400 95 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -490,17 +490,17 @@ Button
 	font			"asrafel"
 	fontjustify		center center
 	fontscale		0.8
-	fontpos			35 8
+	fontpos			30 8
 } 
 resource
 Button
 {
 	name			"Default"
-	rect			515 405 24 24
+	rect			525 405 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"tri_button_ps3"	
+	shader			"y_button_xbox"	
 	allowactivate	false
 }
 
@@ -589,9 +589,9 @@ Label
 resource
 Button
 {
-	title			"Zurück"
+	title			"Retour"
 	name			"Default"
-	rect			510 355 100 35
+	rect			515 355 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -606,11 +606,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			515 360 24 24
+	rect			520 360 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/FRA/loadsave2.urc
+++ b/assets/pak6_VorpalFix/FRA/loadsave2.urc
@@ -53,6 +53,17 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+resource
+Label
+{
+	name			"bigcover_black"
+	rect			358 101 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 1.00
+	borderstyle		"NONE"
+	fadein			1.0
+	inversealpha
+}
 
 // LOAD SHOTS
 resource
@@ -244,7 +255,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 2st
@@ -278,7 +289,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 3rd
@@ -312,7 +323,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 4th
@@ -346,7 +357,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 5th
@@ -380,7 +391,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 6th
@@ -414,7 +425,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // LOAD BUTTONS

--- a/assets/pak6_VorpalFix/FRA_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/FRA_ps3/loadsave2.urc
@@ -591,7 +591,7 @@ Button
 {
 	title			"Retour"
 	name			"Default"
-	rect			100 400 100 35
+	rect			515 355 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -606,7 +606,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			105 405 24 24
+	rect			520 360 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"

--- a/assets/pak6_VorpalFix/INT/loadsave2.urc
+++ b/assets/pak6_VorpalFix/INT/loadsave2.urc
@@ -53,6 +53,17 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+resource
+Label
+{
+	name			"bigcover_black"
+	rect			358 101 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 1.00
+	borderstyle		"NONE"
+	fadein			1.0
+	inversealpha
+}
 
 // LOAD SHOTS
 resource
@@ -244,7 +255,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 2st
@@ -278,7 +289,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 3rd
@@ -312,7 +323,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 4th
@@ -346,7 +357,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 5th
@@ -380,7 +391,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 6th
@@ -414,7 +425,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // LOAD BUTTONS

--- a/assets/pak6_VorpalFix/INT/loadsave2.urc
+++ b/assets/pak6_VorpalFix/INT/loadsave2.urc
@@ -5,7 +5,7 @@ borderstyle NONE
 bgfill 0 0 0 1
 fullscreen 1
 //fadein 0.5
-//vidmode 3
+//vidmode 3 
 
 //include "ui/common.inc"
 
@@ -211,7 +211,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	5 ui/load/loadF
 	allowactivate	false
-}
+} 
 
 // 1st
 resource
@@ -421,7 +421,7 @@ Button
 resource
 Button
 {
-	title			"LADEN"
+	title			"Load"
 	name			"LoadingButton"
 	rect			300 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -442,7 +442,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
+	shader			"a_button_xbox"	
 	allowactivate	false
 }
 
@@ -450,9 +450,9 @@ Button
 resource
 Button
 {
-	title			"Speichern"
+	title			"Save"
 	name			"SaveButton"
-	rect			400 400 110 35
+	rect			400 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -471,7 +471,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"square_button_ps3"	
+	shader			"x_button_xbox"	
 	allowactivate	false
 }
 
@@ -479,9 +479,9 @@ Button
 resource
 Button
 {
-	title			"LÖSCHEN"
+	title			"Delete"
 	name			"DeleteButton"
-	rect			510 400 100 35
+	rect			500 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -496,11 +496,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			515 405 24 24
+	rect			505 405 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"tri_button_ps3"	
+	shader			"y_button_xbox"	
 	allowactivate	false
 }
 
@@ -518,7 +518,7 @@ Label
 	fontangle		2.1
 	fontspacing		1
 	fontscale		0.8
-}
+} 
 
 resource
 Label
@@ -571,27 +571,27 @@ Button
 	groupid			"delete_group"
 	disable
 	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group\n"
-}
+} 
 
 resource
 Label
 {
 	name			"DiskFull"
-	rect			358 165 256 128
+	rect			358 197 256 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			ui/load/disk_full
 	disable
-}
+} 
 
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Zurück"
+	title			"Back"
 	name			"Default"
-	rect			510 355 100 35
+	rect			500 355 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -606,11 +606,11 @@ resource
 Button
 {
 	name			"Default"
-	rect			515 360 24 24
+	rect			505 360 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/INT_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/INT_ps3/loadsave2.urc
@@ -6,12 +6,17 @@ bgfill 0 0 0 1
 fullscreen 1
 //fadein 0.5
 //vidmode 3 
-//include "ui/common.inc" 
+
+//include "ui/common.inc"
+
 showcommand		"widgetcommand LoadSaveList resetpage\n"
 showcommand		"widgetcommand LoadSaveList CheckErrorState\n"
 showcommand		"widgetcommand LoadSaveList disablegroup delete_group\n"
 showcommand		"widgetcommand LoadSaveList enablegroup bigshot_group\n"
-hidecommand		"widgetcommand MsgBackground disable; widgetcommand DiskFull disable\n" 
+
+
+hidecommand		"widgetcommand MsgBackground disable; widgetcommand DiskFull disable\n"
+
 // List
 resource
 FakkLoadGameClass
@@ -22,7 +27,8 @@ FakkLoadGameClass
 	bgcolor			0.00 0.00 0.00 0.70
 	borderstyle		"NONE"
 	neverdraw
-} 
+}
+
 // BIG PREVIEW
 resource
 Label
@@ -47,6 +53,7 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+
 // LOAD SHOTS
 resource
 Button
@@ -95,7 +102,6 @@ Label
 	rect			21 314 128 90
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
-
 	staticshader	15 ui/load/blank
 	borderstyle		"NONE"
 }
@@ -108,7 +114,8 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	staticshader	17 ui/load/blank
 	borderstyle		"NONE"
-} 
+}
+
 resource
 Label
 {
@@ -119,7 +126,25 @@ Label
 	borderstyle		"NONE"
 	shader			ui/loadgame/deleteconfirm
 	disable
-} 
+}
+
+// PAGE NUM INDICATOR
+resource
+Label
+{
+	title			""
+	name			"PageNum"
+	rect			151 412 20 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	font			"asrafel"
+	fontjustify		center center
+	fontscale		0.70
+	fontspacing		1.0
+	fontangle		1.5
+}
+
 // Background
 resource
 Label
@@ -187,6 +212,7 @@ Label
 	staticshader	5 ui/load/loadF
 	allowactivate	false
 } 
+
 // 1st
 resource
 Button
@@ -214,9 +240,13 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
+	
+
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-} 
+
+}
+
 // 2st
 resource
 Button
@@ -249,7 +279,8 @@ Button
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
 
-} 
+}
+
 // 3rd
 resource
 Button
@@ -282,7 +313,8 @@ Button
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
 
-} 
+}
+
 // 4th
 resource
 Button
@@ -315,7 +347,8 @@ Button
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
 
-} 
+}
+
 // 5th
 resource
 Button
@@ -348,7 +381,8 @@ Button
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
 
-} 
+}
+
 // 6th
 resource
 Button
@@ -378,11 +412,11 @@ Button
 	clicksound		"sound/ui/projector_long.wav"
 	
 
-
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
 
-} 
+}
+
 // LOAD BUTTONS
 resource
 Button
@@ -485,6 +519,7 @@ Label
 	fontspacing		1
 	fontscale		0.8
 } 
+
 resource
 Label
 {
@@ -499,7 +534,8 @@ Label
 	fontangle		2.1
 	fontspacing		1
 	fontscale		0.85
-} 
+}
+
 resource
 Label
 {
@@ -536,6 +572,7 @@ Button
 	disable
 	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group\n"
 } 
+
 resource
 Label
 {
@@ -547,13 +584,14 @@ Label
 	shader			ui/load/disk_full
 	disable
 } 
+
 // RETURN BUTTON
 resource
 Button
 {
 	title			"Back"
 	name			"Default"
-	rect			100 400 100 35
+	rect			500 355 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -568,7 +606,7 @@ resource
 Button
 {
 	name			"Default"
-	rect			105 405 24 24
+	rect			505 360 24 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"

--- a/assets/pak6_VorpalFix/INT_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/INT_ps3/loadsave2.urc
@@ -53,6 +53,17 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+resource
+Label
+{
+	name			"bigcover_black"
+	rect			358 101 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 1.00
+	borderstyle		"NONE"
+	fadein			1.0
+	inversealpha
+}
 
 // LOAD SHOTS
 resource
@@ -244,7 +255,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 2st
@@ -278,7 +289,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 3rd
@@ -312,7 +323,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 4th
@@ -346,7 +357,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 5th
@@ -380,7 +391,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 6th
@@ -414,7 +425,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // LOAD BUTTONS


### PR DESCRIPTION
Here's the new Load Screen with the (B Back) button prompt moved, I based the new position on the position of the Xbox 360 prompt for changing device, and then stick it to the right depending on that language's already existing prompts (I tried placing it center horizontally based to the X360 prompt but it looked a bit awkward).

Restoring the page number was no big deal, they actually didn't even bothered removing it for other languages. I also changed the English file design to fit the rest (just line breakes etc.).

Some mock ups as usual.
English:
![load Moved Button Prompts_INT](https://github.com/user-attachments/assets/ae5d2d2a-2957-41e6-a596-8269ba3217cd)
French:
![load Moved Button Prompts_FRA](https://github.com/user-attachments/assets/f59cf1a3-4dc9-489b-bb65-30310dc7b2bf)
German/Spanish:
![load Moved Button Prompts_DEU_ESN](https://github.com/user-attachments/assets/c58975b7-57af-48b9-8db1-f47ed354b969)

As a bonus I restored some missing animations, now the TV turns on when you enter the screen and off when you leave. I didn't do the same for the TV doors since they were only visible for a split second when you enter the menu and nothing else, which is barely visible due to the menu now having fadein.

Hope you like it!