### PR TITLE
Final fixes for PC and Console menus

### DIFF
--- a/assets/loc/DEU/base_g_VorpalFix/ui/controls.urc
+++ b/assets/loc/DEU/base_g_VorpalFix/ui/controls.urc
@@ -12,7 +12,7 @@ showcommand "widgetcommand alice3d setanim idle_stand_rocktoes\n"
 allowactivate	true
 keycommand		1 "widgetcommand TitleBar activategroup group_video\n"
 keycommand		2 "widgetcommand TitleBar activategroup group_audio\n"
-keycommand		3 "widgetcommand TitleBar activategroup group_control_pc\n"
+keycommand		3 "widgetcommand TitleBar activategroup group_control\n"
 keycommand		4 "widgetcommand TitleBar activategroup group_game\n"
 
 // Mirror background
@@ -169,15 +169,20 @@ Label
 resource
 Button
 {
+	title			"Zurück"
 	name			"Default"
-	rect			0 456 80 24
-	fgcolor			1.00 1.00 1.00 1.00
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/back_button
-	hovershader		ui/back_button_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
 	stuffcommand	"popmenu"
 	groupid			"group_main"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			25 5
+	fontscale		0.8
 	direction		from_bottom 0.5
 	allowactivate	false
 }
@@ -205,33 +210,9 @@ Label
 	borderstyle		"NONE"
 	shader			ui/control/head_2
 	groupid			"group_main"
-	
 	allowactivate	false
-} 
-resource
-Label
-{
-	name			"Default"
-	rect			75 330 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"ui/control/hslider_prev"
-	groupid			"group_main"
-	allowactivate	false
-} 
-resource
-Label
-{
-	name			"Default"
-	rect			257 330 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"ui/control/hslider_next"
-	groupid			"group_main"
-	allowactivate	false
-} 
+}
+
 // hotspots
 resource
 Button
@@ -241,7 +222,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		2
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_video\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_video\n"
 	groupid			"group_main"
@@ -254,7 +234,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		3
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_audio\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_audio\n"
 	groupid			"group_main"
@@ -267,9 +246,8 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		4
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_control\n"
-	stuffcommand	"widgetcommand TitleBar activategroup group_control_pc\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
 	groupid			"group_main"
 }
 resource
@@ -280,7 +258,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		1
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_game\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_game\n"
 	groupid			"group_main"
@@ -349,7 +326,7 @@ Label
 resource
 Button
 {
-	title			"Back"
+	title			"Zurück"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -358,55 +335,30 @@ Button
 	shader			ui/buttons/apply
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_main\n"
-	groupid			"group_control_pc"
-	
+	groupid			"group_control"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		6
+	fontpos			37 8
 }
 
 // RESET BUTTON
 resource
 Button
 {
-	title			"Reset"
+	title			"Zurücksetzen"
 	name			"Default"
-	rect			170 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/apply
-	hovershader		ui/buttons/apply_hover
-	stuffcommand	"exec default_pc.cfg; vid_restart; popmenu 0\n"
-	groupid			"group_control_pc"
-	
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	ordernumber		7
-}
-
-// JOYSTICK
-resource
-Button
-{
-	title			"Controller"
-	name			"Default"
-	rect			290 400 100 35
+	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			ui/buttons/plaque
 	hovershader		ui/buttons/plaque_hover
-	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
-	groupid			"group_control_pc"
-	
+	stuffcommand	"exec default.cfg; vid_restart; popmenu 0\n"
+	groupid			"group_control"
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			13 8
-	fontscale		0.8	
-	ordernumber		34
+	fontscale		0.8
 }
 
 // BIND LIST
@@ -419,211 +371,12 @@ FakkBindList
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"3D_BORDER"
-	filename		bind_pc.scr
+	filename		ui/bind.scr
 	font			"asrafel"
-	groupid			"group_control_pc"
-	ordernumber		5
+	groupid			"group_control"
+	ordernumber		1
 }
 
-resource
-Label
-{
-	name			"Default"
-	rect			0 0 640 480
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"controls_pc"
-	groupid			"group_control"
-}
-resource
-Label
-{
-	title			"Alt Attack / Climb Up"
-	name			"Default"
-	rect			0 140 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Next Weapon"
-	name			"Default"
-	rect			0 175 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Move"
-	name			"Default"
-	rect			0 270 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Menu Navigation"
-	name			"Default"
-	rect			120 376 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Turn / Aim"
-	name			"Default"
-	rect			350 376 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Attack / Climb Down"
-	name			"Default"
-	rect			467 290 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Jump / Swim Up"
-	name			"Default"
-	rect			467 260 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Use / Swim Down"
-	name			"Default"
-	rect			467 230 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Alt Attack / Climb Up"
-	name			"Default"
-	rect			467 202 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Prev Weapon"
-	name			"Default"
-	rect			467 175 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Attack / Climb Down"
-	name			"Default"
-	rect			467 140 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Pause / Exit Menu"
-	name			"Default"
-	rect			270 110 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Controls"
-	name			"Default"
-	rect			50 50 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left center
-	fontscale		2.0
-	dropshadow		1
-}
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			50 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_control_pc\n"
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	ordernumber		35
-} 
 // --------------------------------------
 // --------------------------------------
 // VIDEO GROUP
@@ -634,7 +387,7 @@ Button
 resource
 Button
 {
-	title			"Apply"
+	title			"Anwenden"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -644,18 +397,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_video; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_video"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		15
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Abbrechen"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -665,19 +417,18 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_video; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_video"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		16
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // RESOLUTION
 resource
 Label
 {
-	title			"Resolution"
-	name			"ResolutionTxt"
+	title			"Auflösung"
+	name			"Default"
 	rect			68 78 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -685,7 +436,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -698,20 +448,24 @@ List
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		center top
-	
-
-	highlighttextwidget "ResolutionTxt"
-	ordernumber		8
 
 	linkcvar		"r_mode"
+	additem			3 640x480
+	additem			4 800x600
+	additem			5 960x720
+	additem			6 1024x768
+	additem			7 1152x864
+	additem			8 1280x1024
+	additem			9 1600x1200
+	additem			-1 Benutzerdefinierte
 }
 
 // COLOR DEPTH
 resource
 Label
 {
-	title			"Color Depth"
-	name			"ColorTxt"
+	title			"Farbtiefe"
+	name			"Default"
 	rect			68 118 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -719,7 +473,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -733,21 +486,17 @@ List
 	font			"asrafel"
 	fontjustify		center top
 
-	highlighttextwidget "ColorTxt"
-	ordernumber		9
-
 	linkcvar		"r_colorbits"
 	additem			16 16Bit
 	additem			32 32Bit
-	
 }
 
 // FULLSCREEN
 resource
 Label
 {
-	title			"Fullscreen"
-	name			"FullscreenTxt"
+	title			"Vollbildschirm"
+	name			"Default"
 	rect			68 158 210 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -755,7 +504,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 CheckBox
@@ -770,19 +518,15 @@ CheckBox
 	fontjustify		right center
 	linkcvar		"r_fullscreen"
 
-	highlighttextwidget "FullscreenTxt"
-	ordernumber		10
-
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-	
 }
 
 // BRIGHTNESS
 resource
 Label
 {
-	title			"Brightness"
+	title			"Helligkeit"
 	name			"Brightness"
 	rect			68 188 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -791,7 +535,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 Slider
@@ -807,17 +550,13 @@ Slider
 	setrange		.5 1.5
 	stepsize		.05
 	font			"asrafel"
-	
-
-	highlighttextwidget "Brightness"
-	ordernumber		11
 }
 
 // TEXTURE DETAIL
 resource
 Label
 {
-	title			"Texture Detail"
+	title			"Texturen-Detail"
 	name			"Texture_Detail"
 	rect			68 238 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -826,7 +565,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 Slider
@@ -842,17 +580,13 @@ Slider
 	setrange		3 0
 	stepsize		-1
 	font			"asrafel"
-	
-
-	highlighttextwidget "Texture_Detail"
-	ordernumber		12
 }
 
 // TEXTURE DEPTH
 resource
 Label
 {
-	title			"Texture Depth"
+	title			"Texturen"
 	name			"Texture_Bits"
 	rect			68 278 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -861,7 +595,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -878,18 +611,14 @@ List
 	linkcvar		"r_texturebits"
 	additem			16 16Bit
 	additem			32 32Bit
-	
-
-	highlighttextwidget "Texture_Bits"
-	ordernumber		13
 }
 
 // DETAIL TEXTURES
 resource
 Label
 {
-	title			"Detail Textures"
-	name			"DetailTxt"
+	title			"Detaillierte Texturen"
+	name			"Default"
 	rect			68 338 210 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -897,7 +626,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 CheckBox
@@ -914,10 +642,6 @@ CheckBox
 
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-	
-
-	highlighttextwidget "DetailTxt"
-	ordernumber		14
 }
 
 // --------------------------------------
@@ -930,7 +654,7 @@ CheckBox
 resource
 Button
 {
-	title			"Apply"
+	title			"Anwenden"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -940,18 +664,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_audio; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_audio"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		23
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Abbrechen"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -961,19 +684,18 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_audio; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_audio"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		24
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // SOUND DRIVER
 resource
 Label
 {
-	title			"Sound Driver"
-	name			"DriverTxt"
+	title			"Soundtreiber"
+	name			"Default"
 	rect			68 78 200 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1001,16 +723,13 @@ List
 	additem			a3d2
 	additem			eax
 	additem			eax2
-
-	highlighttextwidget "DriverTxt"
-	ordernumber		17
 }
 
 // MUSIC VOLUME
 resource
 Label
 {
-	title			"Music Volume"
+	title			"Lautstärke Musik"
 	name			"Music_Volume"
 	rect			68 168 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1034,16 +753,13 @@ Slider
 	setrange		0 1
 	stepsize		.05
 	font			"asrafel"
-
-	highlighttextwidget "Music_Volume"
-	ordernumber		19
 }
 
 // SFX VOLUME
 resource
 Label
 {
-	title			"Effects Volume"
+	title			"Lautstärke Soundeffekte"
 	name			"SFX_Volume"
 	rect			68 208 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1067,17 +783,14 @@ Slider
 	setrange		0 1
 	stepsize		.05
 	font			"asrafel"
-
-	highlighttextwidget "SFX_Volume"
-	ordernumber		20
 }
 
 // SPEAKER TYPE
 resource
 Label
 {
-	title			"Speaker Type"
-	name			"SpeakerTxt"
+	title			"Lautsprechertyp"
+	name			"Default"
 	rect			68 118 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1100,20 +813,17 @@ List
 
 	linkcvar		"s_speaker_type"
 	additem			0 "Normal"
-	additem			1 "Headphones"
+	additem			1 "Kopfhörer"
 	additem			3 "Surround"
-	additem			4 "Quad"
-
-	highlighttextwidget "SpeakerTxt"
-	ordernumber		18
+	additem			4 "Vier Lautsprecher"
 }
 
 // QUALITY
 resource
 Label
 {
-	title			"Quality"
-	name			"QualityTxt"
+	title			"Qualität"
+	name			"Default"
 	rect			68 258 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1137,18 +847,14 @@ List
 	linkcvar		"s_khz"
 	additem			22 "22 khz"
 	additem			44 "44 khz"
-
-	highlighttextwidget "QualityTxt"
-	ordernumber		21
-
 }
 
 // FORCE 8BIT
 resource
 Label
 {
-	title			"Force 8bits"
-	name			"8BitsTxt"
+	title			"8 Bit verwenden"
+	name			"Default"
 	rect			68 298 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1172,9 +878,6 @@ CheckBox
 
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-
-	highlighttextwidget "8BitsTxt"
-	ordernumber		22
 }
 
 // --------------------------------------
@@ -1188,7 +891,7 @@ CheckBox
 resource
 Button
 {
-	title			"Apply"
+	title			"Anwenden"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1198,18 +901,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_game; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_game"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		32
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Abbrechen"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1219,18 +921,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_game; toggleconsole; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_game"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		33
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // SENSITIVITY
 resource
 Label
 {
-	title			"Sensitivity"
+	title			"Empfindlichkeit"
 	name			"Mouse_Sensitivity"
 	rect			68 80 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1255,17 +956,14 @@ Slider
 	slidertype		float
 	stepsize		1
 	font			"asrafel"
-
-	highlighttextwidget "Mouse_Sensitivity"
-	ordernumber		25
 }
 
 // INVERT MOUSE
 resource
 Label
 {
-	title			"Invert Mouse"
-	name			"InvertMouseTxt"
+	title			"Mausblick umkehren"
+	name			"Default"
 	rect			68 130 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1292,17 +990,13 @@ CheckBox
 
 	checked_command		"set m_pitch -0.022"
 	unchecked_command	"set m_pitch 0.022"
-
-	highlighttextwidget "InvertMouseTxt"
-	ordernumber		26
-
 }
 
 // CAMERA DISTANCE
 resource
 Label
 {
-	title			"Camera Distance"
+	title			"Kameradistanz"
 	name			"Camera_Distance"
 	rect			68 158 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1323,18 +1017,14 @@ Slider
 	setrange		76 192
 	stepsize		4
 	font			"asrafel"
-
-	highlighttextwidget "Camera_Distance"
-	ordernumber		27
-
 }
 
 // ALWAYS RUN
 resource
 Label
 {
-	title			"Always Run"
-	name			"AlwaysRunTxt"
+	title			"Immer Rennen"
+	name			"Default"
 	rect			68 210 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1358,18 +1048,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "AlwaysRunTxt"
-	ordernumber		28
-
 }
 
 // JUMP RETICLE
 resource
 Label
 {
-	title			"Jump Reticle"
-	name			"JumpReticleTxt"
+	title			"Sprunganzeige"
 	rect			68 270 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1390,17 +1075,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "JumpReticleTxt"
-	ordernumber		29
 }
 
 // TARGET RETICLE
 resource
 Label
 {
-	title			"Target Reticle"
-	name			"TargetReticleTxt"
+	title			"Fadenkreuz"
 	rect			68 290 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1421,17 +1102,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "TargetReticleTxt"
-	ordernumber		30
 }
 
 // SUBTITLES
 resource
 Label
 {
-	title			"Subtitles"
-	name			"SubtitlesTxt"
+	title			"Untertitel"
 	rect			68 330 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1452,10 +1129,36 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
+}
 
-	highlighttextwidget "SubtitlesTxt"
-	ordernumber		31
+// CONSOLE
+resource
+Label
+{
+	title			"Konsole"
+	rect			68 350 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 350 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_console"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	checked_command		"toggleconsole\n"
+	unchecked_command	"toggleconsole\n"
 }
 
 end.
-ÍÍÍÂ¬

--- a/assets/loc/DEU/base_g_VorpalFix/ui/credits.urc
+++ b/assets/loc/DEU/base_g_VorpalFix/ui/credits.urc
@@ -3,11 +3,11 @@ fadeoverlay 0.5
 bgcolor 0 0 0 1
 borderstyle NONE
 bgfill 0 0 0 1
-fullscreen 1 
+fullscreen 1
 
 showcommand "widgetcommand page2 activategroup group_page1\n"
 showcommand "widgetcommand Rogue_Glow enable\n"
-showcommand "widgetcommand EA_Glow enable\n"
+showcommand "widgetcommand EA_Glow hide\n"
 showcommand	"widgetcommand title1 resetscroll\n"
 
 //waitcommand "widgetcommand page1 activategroup group_page2" 7000
@@ -52,7 +52,7 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	3 ui/credits/creditsE
-} 
+}
 
 // PAGE
 resource
@@ -99,7 +99,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	11 ui/credits/pageD
 	direction		from_point 0.5 250 0
-} 
+}
 
 // --------------------------------
 // PAGE1
@@ -109,7 +109,7 @@ AutoScroll
 {
 	title			"AutoScroll1"
 	name			"title1"
-	rect			30 95 246 280
+	rect			30 95 246 275
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -119,15 +119,15 @@ AutoScroll
 	fontspacing		0 -8
 	fontscale		0.90
 	direction		from_point 0.5 250 0
-	groupid			"group_page1" 
-	
-	scrollspeed		1.2 
-	
-	forcescissor 
-	
+	groupid			"group_page1"
+
+	scrollspeed		1.2
+
+	forcescissor
+
 	addimage		"ui/credits/alice" 96 5 64 128
 //	addimage		"ui/credits/rabbit" 60 130 128 128
-//	addimage		"ui/credits/bill" 138 154 128 128 
+//	addimage		"ui/credits/bill" 138 154 128 128
 
 	addline			" "
 	addline			" "
@@ -140,20 +140,19 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
-	
-	addline			"=== For Electronic Arts ==="
-	addline			" " 
-	
-	addline			"Design, Development, and Production"
+	addline			" "
+
+	addline			"Electronic Arts"
+
+	addline			"Design, Entwicklung und Produktion"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"American McGee"
 	addline			"R.J. Berg"
 	addline			"Billy Delli-Gatti"
 	addline			"Jordan David Maynard"
-	addline			" " 
-	
-	addline			"Marketing and Public Relations"
+	addline			" "
+
+	addline			"Marketing und PR"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jonathan Harris"
 	addline			"Mike Jeffress"
@@ -161,13 +160,13 @@ AutoScroll
 	addline			"Jason S. Andersen"
 	addline			"Noreen Dante"
 	addline			"Gaylene Nagel"
-	addline			" " 
-	
-	addline			"Testing"
+	addline			" "
+
+	addline			"Tests"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"David McCormick, Lead"
-	addline			"Justin Holst, Asst. Lead"
-	addline			"Chad Schnittjer, Asst. Lead"
+	addline			"David McCormick, Testleitung"
+	addline			"Justin Holst, Assistenz Testleitung"
+	addline			"Chad Schnittjer, Assistenz Testleitung"
 	addline			"James Stanley"
 	addline			"Rad Christian"
 	addline			"Mike Kaiser"
@@ -181,25 +180,9 @@ AutoScroll
 	addline			"Seth Mespelli"
 	addline			"David Miller"
 	addline			"Rob Walker"
-	addline			" " 
-	
-	addline			"Localization Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Carole Celle"
-	addline			" " 
-	
-	addline			"Translation Coordinator"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Clare Parkes"
-	addline			"Rebecca Gordon"
-	addline			" " 
-	
-	addline			"Language Testing Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Sylvain Caburrosso"
-	addline			" " 
-	
-	addline			"Localization Testing"
+	addline			" "
+
+	addline			"Lokalisierungstests"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Colin Clarke"
 	addline			"Daryl Humdy"
@@ -209,68 +192,86 @@ AutoScroll
 	addline			"Roger Metcalf"
 	addline			"Daren Hooper"
 	addline			"AC Martin"
-	addline			" " 
-	
+	addline			"Timothy Johns"
+	addline			" "
+
 	addline			"Open & Close Cinematics"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"by Little Beast"
-	addline			"San Francisco, CA"
-	addline			"R. Zane Rutledge, Director"
-	addline			"Matthew Fassberg, Producer"
-	addline			" " 
-	
-	addline			"Digital Matte Painting & Illustrations"
+	addline			"von Little Beast"
+	addline			"San Francisco, Kalifornien"
+	addline			"R. Zane Rutledge, Direktor"
+	addline			"Matthew Fassberg, Produzent"
+	addline			" "
+
+	addline			"Digital Matte-Zeichnungen"
+	addline			"und Illustrationen"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"lxl"
-	addline			" " 
-	
-	addline			"Computer Animation"
+	addline			" "
+
+	addline			"Computeranimation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Matthew Hendershot"
 	addline			"Jamie Houk"
 	addline			"R. Zane Rutledge"
-	addline			" " 
-	
-	addline			"Music"
+	addline			" "
+
+	addline			"Musik produziert, komponiert"
+	addline			"und arrangiert"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Produced, Composed and Arranged"
-	addline			"by Chris Vrenna"
+	addline			"von Chris Vrenna"
 	addline			" "
-	addline			"Additional music programming &"
-	addline			"performance by Mark Blasquez"
+	addline			"Zusätzliche Musikprogrammierung"
+	addline			"und interpretation"
+	addline			"von Mark Blasquez"
 	addline			" "
-	addline			"Additional girl choir performance"
-	addline			"by Jessicka"
-	addline			" " 
-	
-	addline			"Sound Design, Recording,"
-	addline			"Processing, and FX"
+	addline			"Zusätzlicher Mädchenchor"
+	addline			"von Jessicka"
+	addline			" "
+
+	addline			"Sounddesign, Sprachaufnahmen,"
+	addline			"Bearbeitung und Soundeffekte"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ken Felton"
 	addline			"Marc Farley"
 	addline			"Mat Mitchell"
 	addline			"Aaron Thibault"
 	addline			"Stretch Williams"
-	addline			" " 
-	
-	addline			"Voice Talent"
+	addline			" "
+
+	addline			"Sprecher"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Susie Brann"
 	addline			"Roger Jackson"
 	addline			"Jarion Monroe"
 	addline			"Andrew Chaikin"
 	addline			"Anni Long"
-	addline			" " 
-	
-	addline			"International Development"
+	addline			"Eva Michaelis"
+	addline			"Marianne Bernhardt"
+	addline			"Michael Bideller"
+	addline			"Sven Dahlem"
+	addline			"Klaus Dittmann"
+	addline			"Dagmar Dreke"
+	addline			"Jörg Gillner"
+	addline			"Isabella Grothe"
+	addline			"Klaus-Peter Kaehler"
+	addline			"Marco Kröger"
+	addline			"Holger Löwenberg"
+	addline			"Gerhard Marcel"
+	addline			"Frank Schröder"
+	addline			"Achim Schülke"
+	addline			"Marc Seidenberg"
+	addline			" "
+
+	addline			"Inernationale Entwicklung"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Atsuko Matsumoto"
 	addline			"Dan Roisman"
 	addline			"John Pemberton"
 	addline			"Gabriel Gils Carbo"
 	addline			"Lafayette Taylor"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Creative Services"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Adrienne Rogers"
@@ -283,9 +284,9 @@ AutoScroll
 	addline			"Corey Higgins"
 	addline			"Greg Roensch"
 	addline			"Ede Clarke"
-	addline			"Michael Kerbow - IMAGIC"
-	addline			" " 
-	
+	addline			"Michael Kerbow (IMAGIC)"
+	addline			" "
+
 	addline			"CAT Lab"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"John Hanley"
@@ -294,17 +295,17 @@ AutoScroll
 	addline			"Brian Sawyer"
 	addline			"Emiliano Miranda"
 	addline			"Dave Caron"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Mastering Lab"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Michael Yasko"
 	addline			"Yakim Hayuk"
 	addline			"Mike Dier"
 	addline			"Chris Espiritu"
-	addline			" " 
-	
-	addline			"Customer Quality Control"
+	addline			" "
+
+	addline			"Qualitätssicherung"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Andrew Young"
 	addline			"Benjamin Crick"
@@ -315,9 +316,77 @@ AutoScroll
 	addline			"Dave Kellum"
 	addline			"Benjamin Smith"
 	addline			"Anthony Barbagallo"
-	addline			" " 
-	
-	addline			"Special Thanks"
+	addline			" "
+
+	addline			"Lokalisierungsprojektmanagerin"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Carole Celle"
+	addline			" "
+
+	addline			"Deutsche Lokalisierungsleitung"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Michaela Bartelt"
+	addline			" "
+
+	addline			"Lokalisierungsprojektmangerin"
+	addline			"Deutschland"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Claudia Stevens"
+	addline			" "
+
+	addline			"Übersetzung"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Claudia Stevens"
+	addline			"Angela Hufschmidt"
+	addline			" "
+
+	addline			"Produktmanager"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Pete Larsen"
+	addline			" "
+
+	addline			"PR"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Bernd Reinartz, Raoul Birkhold"
+	addline			" "
+
+	addline			"Projektmanager Sprachtests"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Sylvain Caburrosso"
+	addline			" "
+
+	addline			"LT-Supervisor"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Dirk Vojtilo"
+	addline			" "
+
+	addline			"Sprachtests"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Manuel Bertrams"
+	addline			" "
+
+	addline			"Leitung Qualitätssicherung"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Frank Buchheim, Lars Berenbrinker"
+	addline			" "
+
+	addline			"Qualitätssicherung"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Frank Gördes"
+	addline			"Lars Berenbrinker"
+	addline			" "
+
+	addline			"Audio-Manager"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"David Lapp"
+	addline			" "
+
+	addline			"Sprachaufnahmen"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Toneworx, Hamburg"
+	addline			" "
+
+	addline			"Besonderer Dank an"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Hilleman, Terry Smith,"
 	addline			"Colin Boswell, Linda Matteson,"
@@ -330,8 +399,8 @@ AutoScroll
 	addline			"Quarium Inc., Leigh Matty,"
 	addline			"Erik Whiteford, Santiago Nunez"
 	addline			"Gerrit Velthoen, Tim Wilson"
-	addline			" " 
-	
+	addline			" "
+
 //	addimage		"ui/credits/rabbit" 60 0 128 128
 	addimage		"ui/credits/bill" 60 0 128 128
 	addline			" "
@@ -339,12 +408,12 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
-	
+	addline			" "
+
 	addline			"=== For Rogue Entertainment ==="
-	addline			" " 
-	
-	addline			"2D Art"
+	addline			" "
+
+	addline			"2D-Grafik"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Fleider"
 	addline			"Christopher 'Derelict' Greenhaw"
@@ -353,18 +422,18 @@ AutoScroll
 	addline			"Stephen Hornback"
 	addline			"Aaron Smith"
 	addline			"Joel F. Thomas Jr."
-	addline			" " 
-	
-	addline			"3D Art/Animation"
+	addline			" "
+
+	addline			"3D-Grafik/Animation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jay Brushwood"
 	addline			"Jose Hernandez"
 	addline			"Steven Maines"
 	addline			"John Turner"
 	addline			"Sung Yi"
-	addline			" " 
-	
-	addline			"Level Design"
+	addline			" "
+
+	addline			"Leveldesign"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Christian Cummings"
 	addline			"Brandon James"
@@ -373,54 +442,54 @@ AutoScroll
 	addline			"Cameron Lamprecht"
 	addline			"Brian Patenaude"
 	addline			"Bobby Pavlock"
-	addline			" " 
-	
-	addline			"Design Support"
+	addline			" "
+
+	addline			"Grafikunterstützung"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Zdim"
-	addline			" " 
-	
-	addline			"Programming"
+	addline			" "
+
+	addline			"Programmierung"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Sean Fleming"
 	addline			"Peter Mack"
 	addline			"Darin McNeil"
 	addline			"Joe Waters"
-	addline			" " 
-	
-	addline			"Producer"
+	addline			" "
+
+	addline			"Produzent"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jim Molinets"
-	addline			" " 
-	
-	addline			"Business"
+	addline			" "
+
+	addline			"Geschäftliches"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Barrett Alexander"
 	addline			"Matt Kelso"
 	addline			" "
-	
-	addline			"Very Special Thanks"
+
+	addline			"Ganz besonderen Dank an"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ritual Entertainment:"
-	addline			"Beau Anderson, 3D Art"
-	addline			"Mark Dochtermann, Programming"
-	addline			"Jim Dosé, Programming"
-	addline			"Levelord, Level Design"
-	addline			"Patrick Hook, Level Design"
+	addline			"Beau Anderson, 3D-Grafik"
+	addline			"Mark Dochtermann, Programmierung"
+	addline			"Jim Dosé, Programmierung"
+	addline			"Levelord, Leveldesign"
+	addline			"Patrick Hook, Leveldesign"
 	addline			" "
-	
-	addline			"Valued Contributors"
+
+	addline			"Berater"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Won Choi, Art"
-	addline			"Lee Dotson, 2D Art"
-	addline			"Ciara Gay,  Alice Animation Actor"
-	addline			"Will Loconto, Sound Design"
-	addline			"Patrick Magruder, Programming"
-	addline			"Mike O'Rourke, 3D Art"
-	addline			"Robert Selitto, Level Design"
-	addline			" " 
-	
-	addline			"Testing"
+	addline			"Won Choi, Grafik"
+	addline			"Lee Dotson, 2D-Grafik"
+	addline			"Ciara Gay, Animationsmodell Alice"
+	addline			"Will Loconto, Sounddesign"
+	addline			"Patrick Magruder, Programmierung"
+	addline			"Mike O'Rourke, 3D-Grafik"
+	addline			"Robert Selitto, Leveldesign"
+	addline			" "
+
+	addline			"Tests"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Brock Boutte"
 	addline			"Shane Boydston"
@@ -447,12 +516,8 @@ AutoScroll
 	addline			"Cliff Ritchey"
 	addline			"Karen 'Scout' Sparks"
 	addline			"Marlena Troncoso"
-	addline			" " 
-	
-	addline			"Dog"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Spike"
-} 
+	addline			" "
+}
 
 resource
 Button
@@ -464,10 +529,10 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll"
+	stuffcommand	"widgetcommand title1 resetscroll; widgetcommand EA_Glow hide; widgetcommand Rogue_Glow enable\n"
 	shader			ui/credits/ea_glow
 	hovershader		ui/credits/ea_logo.tga
-} 
+}
 
 resource
 Button
@@ -479,44 +544,12 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll 161"
+	stuffcommand	"widgetcommand title1 resetscroll 211; widgetcommand EA_Glow enable; widgetcommand Rogue_Glow hide\n"
 	shader			ui/credits/rogue_glow
 	hovershader		ui/credits/rogue_logo.tga
-} 
-
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			100 370 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	direction		from_point 0.5 250 0
-	groupid			"group_page1"
-	stuffcommand	"widgetcommand Rogue_Glow hide; widgetcommand EA_Glow hide; popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			105 375 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
-	direction		from_point 0.5 250 0
-	groupid			"group_page1"
 }
-//----------------------------------- 
+
+//-----------------------------------
 
 // MOUSE
 resource
@@ -558,5 +591,26 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	7 ui/credits/mouseF
-} 
+}
+
+// RETURN BUTTON
+resource
+Button
+{
+	title			"Zurück"
+	name			"Default"
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"widgetcommand Rogue_Glow hide; widgetcommand EA_Glow hide; popmenu"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
+}
+
 end.

--- a/assets/loc/DEU/base_g_VorpalFix/ui/loadsave.urc
+++ b/assets/loc/DEU/base_g_VorpalFix/ui/loadsave.urc
@@ -5,7 +5,7 @@ borderstyle NONE
 bgfill 0 0 0 1
 fullscreen 1
 //fadein 0.5
-//vidmode 3 
+//vidmode 3
 
 //include "ui/common.inc"
 
@@ -13,8 +13,8 @@ showcommand		"widgetcommand LoadSaveList resetpage\n"
 showcommand		"widgetcommand LoadSaveList CheckErrorState\n"
 showcommand		"widgetcommand LoadSaveList disablegroup delete_group\n"
 showcommand		"widgetcommand LoadSaveList enablegroup bigshot_group\n"
-
-
+showcommand		"widgetcommand bigcover_left resetmotion out\n"
+showcommand		"widgetcommand bigcover_right resetmotion out\n"
 hidecommand		"widgetcommand MsgBackground disable; widgetcommand DiskFull disable\n"
 
 // List
@@ -63,6 +63,38 @@ Label
 	borderstyle		"NONE"
 	fadein			1.0
 	inversealpha
+}
+resource
+Label
+{
+	name			"bigcover_left"
+	rect			381 149 131 166
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/cover_left.tga
+//	staticshader	18 ui/load/lenscap
+	borderstyle		"NONE"
+	groupid			"bigshot_group"
+	disable
+	direction		from_point 0.180 -190 0
+	waitcommand		"widgetcommand bigcover_left resetmotion in" 0
+	waitcommand		"widgetcommand bigcover_left resetmotion out" 500
+}
+resource
+Label
+{
+	name			"bigcover_right"
+	rect			448 143 143 166
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/cover_right.tga
+//	staticshader	18 ui/load/lenscap
+	borderstyle		"NONE"
+	groupid			"bigshot_group"
+	disable
+	direction		from_point 0.180 190 0
+	waitcommand		"widgetcommand bigcover_right resetmotion in" 0
+	waitcommand		"widgetcommand bigcover_right resetmotion out" 500
 }
 
 // LOAD SHOTS
@@ -222,7 +254,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	5 ui/load/loadF
 	allowactivate	false
-} 
+}
 
 // 1st
 resource
@@ -251,8 +283,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -285,8 +317,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -319,8 +351,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -353,8 +385,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -387,8 +419,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -421,8 +453,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -432,87 +464,96 @@ Button
 resource
 Button
 {
-	title			"Load"
 	name			"LoadingButton"
-	rect			300 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			305 405 24 24
+	rect			369 389 64 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group; widgetcommand LoadSaveList loadgame\n"
+	mouseEnterCmd	"widgetcommand DateTime title Laden"
 	borderstyle		"NONE"
-	shader			"a_button_xbox"	
-	allowactivate	false
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
 }
 
 // SAVE BUTTON
 resource
 Button
 {
-	title			"Save"
 	name			"SaveButton"
-	rect			400 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			405 405 24 24
+	rect			465 386 64 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group; widgetcommand LoadSaveList savegame\n"
+	mouseEnterCmd	"widgetcommand DateTime title Speichern"
 	borderstyle		"NONE"
-	shader			"x_button_xbox"	
-	allowactivate	false
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
 }
 
 // DELETE BUTTON
 resource
 Button
 {
-	title			"Delete"
 	name			"DeleteButton"
-	rect			500 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
+	rect			561 382 64 64
+	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+//	stuffcommand	"widgetcommand LoadSaveList removegame"
+	stuffcommand	"widgetcommand LoadSaveList enablegroup delete_group\n"
+	mouseEnterCmd	"widgetcommand DateTime title Loschen"
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
+}
+
 resource
 Button
 {
-	name			"Default"
-	rect			505 405 24 24
+	name			"PrevButton"
+	rect			140 430 22 22
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_med
+	hovershader		ui/loadgame/pushbtn_med_lit
 	borderstyle		"NONE"
-	shader			"y_button_xbox"	
-	allowactivate	false
+	groupid			"lsd_group"
+	hoversound		"sound/ui/hover_3.wav"
+	stuffcommand	"widgetcommand PrevButton triggerwait\n"
+	clicksound		"sound/ui/projector_long.wav"
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
+	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
+	waitcommand		"widgetcommand LoadSaveList prevpage" 350
+}
+resource
+Button
+{
+	name			"NextButton"
+	rect			162 429 22 22
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_med
+	hovershader		ui/loadgame/pushbtn_med_lit
+	borderstyle		"NONE"
+	groupid			"lsd_group"
+	hoversound		"sound/ui/hover_3.wav"
+	stuffcommand	"widgetcommand NextButton triggerwait\n"
+	clicksound		"sound/ui/projector_long.wav"
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
+	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
+	waitcommand		"widgetcommand LoadSaveList nextpage" 350
 }
 
 resource
@@ -529,7 +570,7 @@ Label
 	fontangle		2.1
 	fontspacing		1
 	fontscale		0.85
-} 
+}
 
 resource
 Label
@@ -558,6 +599,7 @@ Label
 	shader			ui/load/deletetext
 	groupid			"delete_group"
 	disable
+	fadein			0.5
 }
 resource
 Button
@@ -582,46 +624,38 @@ Button
 	groupid			"delete_group"
 	disable
 	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group\n"
-} 
+}
 
 resource
 Label
 {
 	name			"DiskFull"
-	rect			358 197 256 64
+	rect			358 165 256 128
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			ui/load/disk_full
 	disable
-} 
+}
 
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Back"
+	title			"Zurück"
 	name			"Default"
-	rect			500 355 100 35
+	rect			0 455 75 25
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			505 360 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"b_button_xbox"	
-	allowactivate	false
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
 }
+
 end.

--- a/assets/loc/DEU/base_g_VorpalFix/ui/newgame.urc
+++ b/assets/loc/DEU/base_g_VorpalFix/ui/newgame.urc
@@ -126,85 +126,25 @@ Button
 	hoversound		sound/ui/loadsave_h.wav
 	clicksound		sound/ui/loadsave_c.wav
 }
-// Button Callouts: 
-resource
-Button
-{
-	title			"Wechseln"
-	name			"Default"
-	rect			200 400 115 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			205 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"dpad_ps3"	
-	allowactivate	false
-}
-resource
-Button
-{
-	title			"Auswählen"
-	name			"Default"
-	rect			50 400 130 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			55 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
-	allowactivate	false
-}
+
 // RETURN BUTTON
 resource
 Button
 {
 	title			"Zurück"
 	name			"Default"
-	rect			350 400 100 35
+	rect			0 455 75 25
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			355 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
 }
+
 end.

--- a/assets/loc/DEU/base_g_VorpalFix/ui/quit.urc
+++ b/assets/loc/DEU/base_g_VorpalFix/ui/quit.urc
@@ -1,0 +1,134 @@
+menu "quit"		640 480 NONE 0.5
+bgcolor			0 0 0 1
+borderstyle		NONE
+bgfill			0 0 0 1
+fullscreen		1
+fadeoverlay		0.5
+
+allowactivate	true
+keycommand		y quit
+keycommand		n popmenu
+
+// Background
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	0 ui/quit/quitA
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	1 ui/quit/quitB
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 0 128 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	2 ui/quit/quitC
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			0 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	3 ui/quit/quitD
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	4 ui/quit/quitE
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 256 128 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	5 ui/quit/quitF
+	allowactivate	false
+}
+
+// BUTTONS
+resource
+Button
+{
+	name			"Default"
+	rect			409 250 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"quit"
+	hovershader		"ui/quit/yes_glow"
+	allowactivate	true
+	ordernumber		1
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+resource
+Button
+{
+	name			"Default"
+	rect			479 250 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"popmenu"
+	hovershader		"ui/quit/no_glow"
+//	allowactivate	false
+	ordernumber		2
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+
+resource
+Button
+{
+	name			"Default"
+	rect			360 412 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"pushmenu credits"
+	hovershader		"ui/quit/credits_glow"
+//	allowactivate	false
+	ordernumber		3
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+
+end.

--- a/assets/loc/ESN/base_s_VorpalFix/ui/controls.urc
+++ b/assets/loc/ESN/base_s_VorpalFix/ui/controls.urc
@@ -12,7 +12,7 @@ showcommand "widgetcommand alice3d setanim idle_stand_rocktoes\n"
 allowactivate	true
 keycommand		1 "widgetcommand TitleBar activategroup group_video\n"
 keycommand		2 "widgetcommand TitleBar activategroup group_audio\n"
-keycommand		3 "widgetcommand TitleBar activategroup group_control_pc\n"
+keycommand		3 "widgetcommand TitleBar activategroup group_control\n"
 keycommand		4 "widgetcommand TitleBar activategroup group_game\n"
 
 // Mirror background
@@ -169,15 +169,20 @@ Label
 resource
 Button
 {
+	title			"Volver"
 	name			"Default"
-	rect			0 456 80 24
-	fgcolor			1.00 1.00 1.00 1.00
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/back_button
-	hovershader		ui/back_button_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
 	stuffcommand	"popmenu"
 	groupid			"group_main"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			28 5
+	fontscale		0.8
 	direction		from_bottom 0.5
 	allowactivate	false
 }
@@ -205,33 +210,9 @@ Label
 	borderstyle		"NONE"
 	shader			ui/control/head_2
 	groupid			"group_main"
-	
 	allowactivate	false
-} 
-resource
-Label
-{
-	name			"Default"
-	rect			75 330 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"ui/control/hslider_prev"
-	groupid			"group_main"
-	allowactivate	false
-} 
-resource
-Label
-{
-	name			"Default"
-	rect			257 330 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"ui/control/hslider_next"
-	groupid			"group_main"
-	allowactivate	false
-} 
+}
+
 // hotspots
 resource
 Button
@@ -241,7 +222,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		2
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_video\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_video\n"
 	groupid			"group_main"
@@ -254,7 +234,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		3
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_audio\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_audio\n"
 	groupid			"group_main"
@@ -267,9 +246,8 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		4
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_control\n"
-	stuffcommand	"widgetcommand TitleBar activategroup group_control_pc\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
 	groupid			"group_main"
 }
 resource
@@ -280,7 +258,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		1
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_game\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_game\n"
 	groupid			"group_main"
@@ -349,7 +326,7 @@ Label
 resource
 Button
 {
-	title			"Back"
+	title			"Volver"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -358,55 +335,30 @@ Button
 	shader			ui/buttons/apply
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_main\n"
-	groupid			"group_control_pc"
-	
+	groupid			"group_control"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		6
+	fontpos			37 8
 }
 
 // RESET BUTTON
 resource
 Button
 {
-	title			"Reset"
+	title			"Reiniciar"
 	name			"Default"
-	rect			170 400 100 35
+	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			ui/buttons/apply
 	hovershader		ui/buttons/apply_hover
-	stuffcommand	"exec default_pc.cfg; vid_restart; popmenu 0\n"
-	groupid			"group_control_pc"
-	
+	stuffcommand	"exec default.cfg; vid_restart; popmenu 0\n"
+	groupid			"group_control"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		7
-}
-
-// JOYSTICK
-resource
-Button
-{
-	title			"Controller"
-	name			"Default"
-	rect			290 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
-	groupid			"group_control_pc"
-	
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			13 8
-	fontscale		0.8	
-	ordernumber		34
+	fontpos			33 10
+	fontscale		0.8
 }
 
 // BIND LIST
@@ -419,211 +371,12 @@ FakkBindList
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"3D_BORDER"
-	filename		bind_pc.scr
+	filename		ui/bind.scr
 	font			"asrafel"
-	groupid			"group_control_pc"
-	ordernumber		5
+	groupid			"group_control"
+	ordernumber		1
 }
 
-resource
-Label
-{
-	name			"Default"
-	rect			0 0 640 480
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"controls_pc"
-	groupid			"group_control"
-}
-resource
-Label
-{
-	title			"Alt Attack / Climb Up"
-	name			"Default"
-	rect			0 140 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Next Weapon"
-	name			"Default"
-	rect			0 175 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Move"
-	name			"Default"
-	rect			0 270 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Menu Navigation"
-	name			"Default"
-	rect			120 376 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Turn / Aim"
-	name			"Default"
-	rect			350 376 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Attack / Climb Down"
-	name			"Default"
-	rect			467 290 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Jump / Swim Up"
-	name			"Default"
-	rect			467 260 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Use / Swim Down"
-	name			"Default"
-	rect			467 230 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Alt Attack / Climb Up"
-	name			"Default"
-	rect			467 202 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Prev Weapon"
-	name			"Default"
-	rect			467 175 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Attack / Climb Down"
-	name			"Default"
-	rect			467 140 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Pause / Exit Menu"
-	name			"Default"
-	rect			270 110 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Controls"
-	name			"Default"
-	rect			50 50 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left center
-	fontscale		2.0
-	dropshadow		1
-}
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			50 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_control_pc\n"
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	ordernumber		35
-} 
 // --------------------------------------
 // --------------------------------------
 // VIDEO GROUP
@@ -634,7 +387,7 @@ Button
 resource
 Button
 {
-	title			"Apply"
+	title			"Aplicar"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -644,18 +397,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_video; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_video"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		15
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Cancelar"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -665,19 +417,18 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_video; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_video"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		16
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // RESOLUTION
 resource
 Label
 {
-	title			"Resolution"
-	name			"ResolutionTxt"
+	title			"Resolución"
+	name			"Default"
 	rect			68 78 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -685,7 +436,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -698,20 +448,24 @@ List
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		center top
-	
-
-	highlighttextwidget "ResolutionTxt"
-	ordernumber		8
 
 	linkcvar		"r_mode"
+	additem			3 640x480
+	additem			4 800x600
+	additem			5 960x720
+	additem			6 1024x768
+	additem			7 1152x864
+	additem			8 1280x1024
+	additem			9 1600x1200
+	additem			-1 Personalizada
 }
 
 // COLOR DEPTH
 resource
 Label
 {
-	title			"Color Depth"
-	name			"ColorTxt"
+	title			"Colores"
+	name			"Default"
 	rect			68 118 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -719,7 +473,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -733,21 +486,17 @@ List
 	font			"asrafel"
 	fontjustify		center top
 
-	highlighttextwidget "ColorTxt"
-	ordernumber		9
-
 	linkcvar		"r_colorbits"
 	additem			16 16Bit
 	additem			32 32Bit
-	
 }
 
 // FULLSCREEN
 resource
 Label
 {
-	title			"Fullscreen"
-	name			"FullscreenTxt"
+	title			"Pantalla completa"
+	name			"Default"
 	rect			68 158 210 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -755,7 +504,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 CheckBox
@@ -770,19 +518,15 @@ CheckBox
 	fontjustify		right center
 	linkcvar		"r_fullscreen"
 
-	highlighttextwidget "FullscreenTxt"
-	ordernumber		10
-
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-	
 }
 
 // BRIGHTNESS
 resource
 Label
 {
-	title			"Brightness"
+	title			"Brillo"
 	name			"Brightness"
 	rect			68 188 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -791,7 +535,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 Slider
@@ -807,17 +550,13 @@ Slider
 	setrange		.5 1.5
 	stepsize		.05
 	font			"asrafel"
-	
-
-	highlighttextwidget "Brightness"
-	ordernumber		11
 }
 
 // TEXTURE DETAIL
 resource
 Label
 {
-	title			"Texture Detail"
+	title			"Detalle de texturas"
 	name			"Texture_Detail"
 	rect			68 238 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -826,7 +565,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 Slider
@@ -842,17 +580,13 @@ Slider
 	setrange		3 0
 	stepsize		-1
 	font			"asrafel"
-	
-
-	highlighttextwidget "Texture_Detail"
-	ordernumber		12
 }
 
 // TEXTURE DEPTH
 resource
 Label
 {
-	title			"Texture Depth"
+	title			"Bits de textura"
 	name			"Texture_Bits"
 	rect			68 278 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -861,7 +595,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -878,18 +611,14 @@ List
 	linkcvar		"r_texturebits"
 	additem			16 16Bit
 	additem			32 32Bit
-	
-
-	highlighttextwidget "Texture_Bits"
-	ordernumber		13
 }
 
 // DETAIL TEXTURES
 resource
 Label
 {
-	title			"Detail Textures"
-	name			"DetailTxt"
+	title			"Texturas de detalle"
+	name			"Default"
 	rect			68 338 210 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -897,7 +626,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 CheckBox
@@ -914,10 +642,6 @@ CheckBox
 
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-	
-
-	highlighttextwidget "DetailTxt"
-	ordernumber		14
 }
 
 // --------------------------------------
@@ -930,7 +654,7 @@ CheckBox
 resource
 Button
 {
-	title			"Apply"
+	title			"Aplicar"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -940,18 +664,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_audio; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_audio"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		23
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Cancelar"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -961,19 +684,18 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_audio; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_audio"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		24
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // SOUND DRIVER
 resource
 Label
 {
-	title			"Sound Driver"
-	name			"DriverTxt"
+	title			"Controlador de sonido"
+	name			"Default"
 	rect			68 78 200 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1001,16 +723,13 @@ List
 	additem			a3d2
 	additem			eax
 	additem			eax2
-
-	highlighttextwidget "DriverTxt"
-	ordernumber		17
 }
 
 // MUSIC VOLUME
 resource
 Label
 {
-	title			"Music Volume"
+	title			"Volumen de música"
 	name			"Music_Volume"
 	rect			68 168 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1034,16 +753,13 @@ Slider
 	setrange		0 1
 	stepsize		.05
 	font			"asrafel"
-
-	highlighttextwidget "Music_Volume"
-	ordernumber		19
 }
 
 // SFX VOLUME
 resource
 Label
 {
-	title			"Effects Volume"
+	title			"Volumen efectos de sonido"
 	name			"SFX_Volume"
 	rect			68 208 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1067,17 +783,14 @@ Slider
 	setrange		0 1
 	stepsize		.05
 	font			"asrafel"
-
-	highlighttextwidget "SFX_Volume"
-	ordernumber		20
 }
 
 // SPEAKER TYPE
 resource
 Label
 {
-	title			"Speaker Type"
-	name			"SpeakerTxt"
+	title			"Tipo de altavoz"
+	name			"Default"
 	rect			68 118 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1100,20 +813,17 @@ List
 
 	linkcvar		"s_speaker_type"
 	additem			0 "Normal"
-	additem			1 "Headphones"
-	additem			3 "Surround"
-	additem			4 "Quad"
-
-	highlighttextwidget "SpeakerTxt"
-	ordernumber		18
+	additem			1 "Auriculares"
+	additem			3 "Sonido envolvente"
+	additem			4 "Altavoces 4 posiciones"
 }
 
 // QUALITY
 resource
 Label
 {
-	title			"Quality"
-	name			"QualityTxt"
+	title			"Calidad"
+	name			"Default"
 	rect			68 258 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1137,18 +847,14 @@ List
 	linkcvar		"s_khz"
 	additem			22 "22 khz"
 	additem			44 "44 khz"
-
-	highlighttextwidget "QualityTxt"
-	ordernumber		21
-
 }
 
 // FORCE 8BIT
 resource
 Label
 {
-	title			"Force 8bits"
-	name			"8BitsTxt"
+	title			"Forzar a 8 bit"
+	name			"Default"
 	rect			68 298 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1172,9 +878,6 @@ CheckBox
 
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-
-	highlighttextwidget "8BitsTxt"
-	ordernumber		22
 }
 
 // --------------------------------------
@@ -1188,7 +891,7 @@ CheckBox
 resource
 Button
 {
-	title			"Apply"
+	title			"Aplicar"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1198,18 +901,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_game; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_game"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		32
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Cancelar"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1219,18 +921,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_game; toggleconsole; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_game"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		33
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // SENSITIVITY
 resource
 Label
 {
-	title			"Sensitivity"
+	title			"Sensibilidad"
 	name			"Mouse_Sensitivity"
 	rect			68 80 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1255,17 +956,14 @@ Slider
 	slidertype		float
 	stepsize		1
 	font			"asrafel"
-
-	highlighttextwidget "Mouse_Sensitivity"
-	ordernumber		25
 }
 
 // INVERT MOUSE
 resource
 Label
 {
-	title			"Invert Mouse"
-	name			"InvertMouseTxt"
+	title			"Invertir ratón"
+	name			"Default"
 	rect			68 130 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1292,17 +990,13 @@ CheckBox
 
 	checked_command		"set m_pitch -0.022"
 	unchecked_command	"set m_pitch 0.022"
-
-	highlighttextwidget "InvertMouseTxt"
-	ordernumber		26
-
 }
 
 // CAMERA DISTANCE
 resource
 Label
 {
-	title			"Camera Distance"
+	title			"Cámara a distancia"
 	name			"Camera_Distance"
 	rect			68 158 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1323,18 +1017,14 @@ Slider
 	setrange		76 192
 	stepsize		4
 	font			"asrafel"
-
-	highlighttextwidget "Camera_Distance"
-	ordernumber		27
-
 }
 
 // ALWAYS RUN
 resource
 Label
 {
-	title			"Always Run"
-	name			"AlwaysRunTxt"
+	title			"Correr siempre"
+	name			"Default"
 	rect			68 210 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1358,18 +1048,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "AlwaysRunTxt"
-	ordernumber		28
-
 }
 
 // JUMP RETICLE
 resource
 Label
 {
-	title			"Jump Reticle"
-	name			"JumpReticleTxt"
+	title			"Retícula de salto"
 	rect			68 270 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1390,17 +1075,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "JumpReticleTxt"
-	ordernumber		29
 }
 
 // TARGET RETICLE
 resource
 Label
 {
-	title			"Target Reticle"
-	name			"TargetReticleTxt"
+	title			"Retícula de objetivo"
 	rect			68 290 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1421,17 +1102,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "TargetReticleTxt"
-	ordernumber		30
 }
 
 // SUBTITLES
 resource
 Label
 {
-	title			"Subtitles"
-	name			"SubtitlesTxt"
+	title			"Subtítulos"
 	rect			68 330 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1452,10 +1129,36 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
+}
 
-	highlighttextwidget "SubtitlesTxt"
-	ordernumber		31
+// CONSOLE
+resource
+Label
+{
+	title			"Consola"
+	rect			68 350 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 350 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_console"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	checked_command		"toggleconsole\n"
+	unchecked_command	"toggleconsole\n"
 }
 
 end.
-ÍÍÍÂ¬

--- a/assets/loc/ESN/base_s_VorpalFix/ui/credits.urc
+++ b/assets/loc/ESN/base_s_VorpalFix/ui/credits.urc
@@ -3,11 +3,11 @@ fadeoverlay 0.5
 bgcolor 0 0 0 1
 borderstyle NONE
 bgfill 0 0 0 1
-fullscreen 1 
+fullscreen 1
 
 showcommand "widgetcommand page2 activategroup group_page1\n"
 showcommand "widgetcommand Rogue_Glow enable\n"
-showcommand "widgetcommand EA_Glow enable\n"
+showcommand "widgetcommand EA_Glow hide\n"
 showcommand	"widgetcommand title1 resetscroll\n"
 
 //waitcommand "widgetcommand page1 activategroup group_page2" 7000
@@ -52,7 +52,7 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	3 ui/credits/creditsE
-} 
+}
 
 // PAGE
 resource
@@ -99,7 +99,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	11 ui/credits/pageD
 	direction		from_point 0.5 250 0
-} 
+}
 
 // --------------------------------
 // PAGE1
@@ -109,7 +109,7 @@ AutoScroll
 {
 	title			"AutoScroll1"
 	name			"title1"
-	rect			30 95 246 280
+	rect			27 100 246 280
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -117,17 +117,17 @@ AutoScroll
 	fontjustify		center center
 //	fontangle		0.4
 	fontspacing		0 -8
-	fontscale		0.90
+	fontscale		0.85
 	direction		from_point 0.5 250 0
-	groupid			"group_page1" 
-	
-	scrollspeed		1.2 
-	
-	forcescissor 
-	
+	groupid			"group_page1"
+
+	scrollspeed		1.2
+
+	forcescissor
+
 	addimage		"ui/credits/alice" 96 5 64 128
 //	addimage		"ui/credits/rabbit" 60 130 128 128
-//	addimage		"ui/credits/bill" 138 154 128 128 
+//	addimage		"ui/credits/bill" 138 154 128 128
 
 	addline			" "
 	addline			" "
@@ -140,20 +140,20 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
-	
-	addline			"=== For Electronic Arts ==="
-	addline			" " 
-	
-	addline			"Design, Development, and Production"
+	addline			" "
+
+	addline			"=== Por Electronic Arts ==="
+	addline			" "
+
+	addline			"Diseño, Desarrollo y Producción"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"American McGee"
 	addline			"R.J. Berg"
 	addline			"Billy Delli-Gatti"
 	addline			"Jordan David Maynard"
-	addline			" " 
-	
-	addline			"Marketing and Public Relations"
+	addline			" "
+
+	addline			"Marketing y Relaciones Públicas"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jonathan Harris"
 	addline			"Mike Jeffress"
@@ -161,13 +161,13 @@ AutoScroll
 	addline			"Jason S. Andersen"
 	addline			"Noreen Dante"
 	addline			"Gaylene Nagel"
-	addline			" " 
-	
-	addline			"Testing"
+	addline			" "
+
+	addline			"Pruebas"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"David McCormick, Lead"
-	addline			"Justin Holst, Asst. Lead"
-	addline			"Chad Schnittjer, Asst. Lead"
+	addline			"David McCormick, Director"
+	addline			"Justin Holst, Asis. Dirección"
+	addline			"Chad Schnittjer, Asis. Dirección"
 	addline			"James Stanley"
 	addline			"Rad Christian"
 	addline			"Mike Kaiser"
@@ -180,26 +180,9 @@ AutoScroll
 	addline			"William Lane"
 	addline			"Seth Mespelli"
 	addline			"David Miller"
-	addline			"Rob Walker"
-	addline			" " 
-	
-	addline			"Localization Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Carole Celle"
-	addline			" " 
-	
-	addline			"Translation Coordinator"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Clare Parkes"
-	addline			"Rebecca Gordon"
-	addline			" " 
-	
-	addline			"Language Testing Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Sylvain Caburrosso"
-	addline			" " 
-	
-	addline			"Localization Testing"
+	addline			" "
+
+	addline			"Pruebas de Idioma"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Colin Clarke"
 	addline			"Daryl Humdy"
@@ -209,69 +192,79 @@ AutoScroll
 	addline			"Roger Metcalf"
 	addline			"Daren Hooper"
 	addline			"AC Martin"
-	addline			" " 
-	
-	addline			"Open & Close Cinematics"
+	addline			"Timothy Johns"
+	addline			" "
+
+	addline			"Secuencias Cinemáticas de"
+	addline			"Apertura y Cierre"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"by Little Beast"
+	addline			"por Little Beast"
 	addline			"San Francisco, CA"
 	addline			"R. Zane Rutledge, Director"
-	addline			"Matthew Fassberg, Producer"
-	addline			" " 
-	
-	addline			"Digital Matte Painting & Illustrations"
+	addline			"Matthew Fassberg, Productor"
+	addline			" "
+
+	addline			"Dibujo Digital e Ilustaciones"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"lxl"
-	addline			" " 
-	
-	addline			"Computer Animation"
+	addline			" "
+
+	addline			"Animaciones"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Matthew Hendershot"
 	addline			"Jamie Houk"
 	addline			"R. Zane Rutledge"
-	addline			" " 
-	
-	addline			"Music"
+	addline			" "
+
+	addline			"Música"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Produced, Composed and Arranged"
-	addline			"by Chris Vrenna"
+	addline			"Producida, Compuesta y Arreglada"
+	addline			"por Chris Vrenna"
 	addline			" "
-	addline			"Additional music programming &"
-	addline			"performance by Mark Blasquez"
+	addline			"Música adicional programada y"
+	addline			"realizada por Mark Blasquez"
 	addline			" "
-	addline			"Additional girl choir performance"
-	addline			"by Jessicka"
-	addline			" " 
-	
-	addline			"Sound Design, Recording,"
-	addline			"Processing, and FX"
+	addline			"Coro femenino realizado por Jessicka"
+	addline			" "
+
+	addline			"Diseño de Sonido, Grabaciones,"
+	addline			"Edición y Efectos"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ken Felton"
 	addline			"Marc Farley"
 	addline			"Mat Mitchell"
 	addline			"Aaron Thibault"
 	addline			"Stretch Williams"
-	addline			" " 
-	
-	addline			"Voice Talent"
+	addline			" "
+
+	addline			"Voces"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Susie Brann"
 	addline			"Roger Jackson"
 	addline			"Jarion Monroe"
 	addline			"Andrew Chaikin"
 	addline			"Anni Long"
-	addline			" " 
-	
-	addline			"International Development"
+	addline			"Sandra Jara"
+	addline			"Richar del Olmo"
+	addline			"Antonio Fernadez"
+	addline			"Elixabete Aldama"
+	addline			"David Bascones"
+	addline			"Regino Ramos"
+	addline			"Luis Paramo"
+	addline			"Julia Martinez"
+	addline			"Jaime Roca"
+	addline			" "
+
+	addline			"Desarrollo Internacional"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Atsuko Matsumoto"
 	addline			"Dan Roisman"
 	addline			"John Pemberton"
 	addline			"Gabriel Gils Carbo"
 	addline			"Lafayette Taylor"
-	addline			" " 
-	
-	addline			"Creative Services"
+	addline			" "
+
+	addline			"Servicios Creativos"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Adrienne Rogers"
 	addline			"Kevin Marburg"
@@ -284,27 +277,22 @@ AutoScroll
 	addline			"Greg Roensch"
 	addline			"Ede Clarke"
 	addline			"Michael Kerbow - IMAGIC"
-	addline			" " 
-	
-	addline			"CAT Lab"
+	addline			" "
+
+	addline			"Laboratorio CYT"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"John Hanley"
-	addline			"Jacob Fernandez"
-	addline			"Mark Gonzales"
-	addline			"Brian Sawyer"
-	addline			"Emiliano Miranda"
-	addline			"Dave Caron"
-	addline			" " 
-	
-	addline			"Mastering Lab"
+	addline			" "
+
+	addline			"Laboratorio de Masterización"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Michael Yasko"
 	addline			"Yakim Hayuk"
 	addline			"Mike Dier"
 	addline			"Chris Espiritu"
-	addline			" " 
-	
-	addline			"Customer Quality Control"
+	addline			" "
+
+	addline			"Control de Calidad"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Andrew Young"
 	addline			"Benjamin Crick"
@@ -315,9 +303,69 @@ AutoScroll
 	addline			"Dave Kellum"
 	addline			"Benjamin Smith"
 	addline			"Anthony Barbagallo"
-	addline			" " 
-	
-	addline			"Special Thanks"
+	addline			" "
+
+	addline			"Director Proyecto Localización"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Carole Celle"
+	addline			" "
+
+	addline			"Coordinador de Traducción"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"José Luis Rovira"
+	addline			" "
+
+	addline			"Traductor"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Cristina Macía"
+	addline			" "
+
+	addline			"Jefe de Producto"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Francesc Caparros"
+	addline			" "
+
+	addline			"Relaciones Públicas"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Oscar Frades"
+	addline			" "
+
+	addline			"Dirección Pruebas Idioma"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Sylvain Caburrosso"
+	addline			" "
+
+	addline			"Supervisor de Pruebas de Idiomas"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Luis Pinés"
+	addline			" "
+
+	addline			"Pruebas de Idioma"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"José Ramón Sagarna"
+	addline			" "
+
+	addline			"Supervisor Control Calidad"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Antonio Yago"
+	addline			" "
+
+	addline			"Control de Calidad"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Tomás Hermida"
+	addline			" "
+
+	addline			"Director de Audio"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"David Lapp"
+	addline			" "
+
+	addline			"Estudio de Grabación"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Taller de Sonido"
+	addline			" "
+
+	addline			"Agradecimientos Especiales"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Hilleman, Terry Smith,"
 	addline			"Colin Boswell, Linda Matteson,"
@@ -330,8 +378,8 @@ AutoScroll
 	addline			"Quarium Inc., Leigh Matty,"
 	addline			"Erik Whiteford, Santiago Nunez"
 	addline			"Gerrit Velthoen, Tim Wilson"
-	addline			" " 
-	
+	addline			" "
+
 //	addimage		"ui/credits/rabbit" 60 0 128 128
 	addimage		"ui/credits/bill" 60 0 128 128
 	addline			" "
@@ -339,12 +387,12 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
-	
-	addline			"=== For Rogue Entertainment ==="
-	addline			" " 
-	
-	addline			"2D Art"
+	addline			" "
+
+	addline			"=== Por Rogue Entertainment ==="
+	addline			" "
+
+	addline			"Diseño 2D"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Fleider"
 	addline			"Christopher 'Derelict' Greenhaw"
@@ -353,18 +401,18 @@ AutoScroll
 	addline			"Stephen Hornback"
 	addline			"Aaron Smith"
 	addline			"Joel F. Thomas Jr."
-	addline			" " 
-	
-	addline			"3D Art/Animation"
+	addline			" "
+
+	addline			"Diseño 3D/Animaciones"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jay Brushwood"
 	addline			"Jose Hernandez"
 	addline			"Steven Maines"
 	addline			"John Turner"
 	addline			"Sung Yi"
-	addline			" " 
-	
-	addline			"Level Design"
+	addline			" "
+
+	addline			"Diseño de Niveles"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Christian Cummings"
 	addline			"Brandon James"
@@ -373,54 +421,54 @@ AutoScroll
 	addline			"Cameron Lamprecht"
 	addline			"Brian Patenaude"
 	addline			"Bobby Pavlock"
-	addline			" " 
-	
-	addline			"Design Support"
+	addline			" "
+
+	addline			"Soporte del Diseño"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Zdim"
-	addline			" " 
-	
-	addline			"Programming"
+	addline			" "
+
+	addline			"Programación"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Sean Fleming"
 	addline			"Peter Mack"
 	addline			"Darin McNeil"
 	addline			"Joe Waters"
-	addline			" " 
-	
-	addline			"Producer"
+	addline			" "
+
+	addline			"Productor"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jim Molinets"
-	addline			" " 
-	
-	addline			"Business"
+	addline			" "
+
+	addline			"Negocios"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Barrett Alexander"
 	addline			"Matt Kelso"
 	addline			" "
-	
-	addline			"Very Special Thanks"
+
+	addline			"Agradecimientos Especiales"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ritual Entertainment:"
-	addline			"Beau Anderson, 3D Art"
-	addline			"Mark Dochtermann, Programming"
-	addline			"Jim Dosé, Programming"
-	addline			"Levelord, Level Design"
-	addline			"Patrick Hook, Level Design"
+	addline			"Beau Anderson, Diseño 3D"
+	addline			"Mark Dochtermann, Programación"
+	addline			"Jim Dosé, Programación"
+	addline			"Levelord, Diseño de Niveles"
+	addline			"Patrick Hook, Diseño de Niveles"
 	addline			" "
-	
-	addline			"Valued Contributors"
+
+	addline			"Colaboradores"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Won Choi, Art"
-	addline			"Lee Dotson, 2D Art"
-	addline			"Ciara Gay,  Alice Animation Actor"
-	addline			"Will Loconto, Sound Design"
-	addline			"Patrick Magruder, Programming"
-	addline			"Mike O'Rourke, 3D Art"
-	addline			"Robert Selitto, Level Design"
-	addline			" " 
-	
-	addline			"Testing"
+	addline			"Won Choi, Diseño"
+	addline			"Lee Dotson, Diseño 2D"
+	addline			"Ciara Gay, Actor de Animación de Alice"
+	addline			"Will Loconto, Diseño de Sonido"
+	addline			"Patrick Magruder, Programación"
+	addline			"Mike O'Rourke, Diseño 3D"
+	addline			"Robert Selitto, Diseño de Sonido"
+	addline			" "
+
+	addline			"Pruebas"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Brock Boutte"
 	addline			"Shane Boydston"
@@ -447,12 +495,8 @@ AutoScroll
 	addline			"Cliff Ritchey"
 	addline			"Karen 'Scout' Sparks"
 	addline			"Marlena Troncoso"
-	addline			" " 
-	
-	addline			"Dog"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Spike"
-} 
+	addline			" "
+}
 
 resource
 Button
@@ -464,10 +508,10 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll"
+	stuffcommand	"widgetcommand title1 resetscroll; widgetcommand EA_Glow hide; widgetcommand Rogue_Glow enable\n"
 	shader			ui/credits/ea_glow
 	hovershader		ui/credits/ea_logo.tga
-} 
+}
 
 resource
 Button
@@ -479,44 +523,12 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll 161"
+	stuffcommand	"widgetcommand title1 resetscroll 191; widgetcommand EA_Glow enable; widgetcommand Rogue_Glow hide\n"
 	shader			ui/credits/rogue_glow
 	hovershader		ui/credits/rogue_logo.tga
-} 
-
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			100 370 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	direction		from_point 0.5 250 0
-	groupid			"group_page1"
-	stuffcommand	"widgetcommand Rogue_Glow hide; widgetcommand EA_Glow hide; popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			105 375 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
-	direction		from_point 0.5 250 0
-	groupid			"group_page1"
 }
-//----------------------------------- 
+
+//-----------------------------------
 
 // MOUSE
 resource
@@ -558,5 +570,26 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	7 ui/credits/mouseF
-} 
+}
+
+// RETURN BUTTON
+resource
+Button
+{
+	title			"Volver"
+	name			"Default"
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"widgetcommand Rogue_Glow hide; widgetcommand EA_Glow hide; popmenu"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
+}
+
 end.

--- a/assets/loc/ESN/base_s_VorpalFix/ui/loadsave.urc
+++ b/assets/loc/ESN/base_s_VorpalFix/ui/loadsave.urc
@@ -5,7 +5,7 @@ borderstyle NONE
 bgfill 0 0 0 1
 fullscreen 1
 //fadein 0.5
-//vidmode 3 
+//vidmode 3
 
 //include "ui/common.inc"
 
@@ -13,8 +13,8 @@ showcommand		"widgetcommand LoadSaveList resetpage\n"
 showcommand		"widgetcommand LoadSaveList CheckErrorState\n"
 showcommand		"widgetcommand LoadSaveList disablegroup delete_group\n"
 showcommand		"widgetcommand LoadSaveList enablegroup bigshot_group\n"
-
-
+showcommand		"widgetcommand bigcover_left resetmotion out\n"
+showcommand		"widgetcommand bigcover_right resetmotion out\n"
 hidecommand		"widgetcommand MsgBackground disable; widgetcommand DiskFull disable\n"
 
 // List
@@ -63,6 +63,38 @@ Label
 	borderstyle		"NONE"
 	fadein			1.0
 	inversealpha
+}
+resource
+Label
+{
+	name			"bigcover_left"
+	rect			381 149 131 166
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/cover_left.tga
+//	staticshader	18 ui/load/lenscap
+	borderstyle		"NONE"
+	groupid			"bigshot_group"
+	disable
+	direction		from_point 0.180 -190 0
+	waitcommand		"widgetcommand bigcover_left resetmotion in" 0
+	waitcommand		"widgetcommand bigcover_left resetmotion out" 500
+}
+resource
+Label
+{
+	name			"bigcover_right"
+	rect			448 143 143 166
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/cover_right.tga
+//	staticshader	18 ui/load/lenscap
+	borderstyle		"NONE"
+	groupid			"bigshot_group"
+	disable
+	direction		from_point 0.180 190 0
+	waitcommand		"widgetcommand bigcover_right resetmotion in" 0
+	waitcommand		"widgetcommand bigcover_right resetmotion out" 500
 }
 
 // LOAD SHOTS
@@ -222,7 +254,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	5 ui/load/loadF
 	allowactivate	false
-} 
+}
 
 // 1st
 resource
@@ -251,8 +283,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -285,8 +317,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -319,8 +351,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -353,8 +385,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -387,8 +419,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -421,8 +453,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -432,87 +464,96 @@ Button
 resource
 Button
 {
-	title			"Load"
 	name			"LoadingButton"
-	rect			300 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			305 405 24 24
+	rect			369 389 64 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group; widgetcommand LoadSaveList loadgame\n"
+	mouseEnterCmd	"widgetcommand DateTime title Cargar"
 	borderstyle		"NONE"
-	shader			"a_button_xbox"	
-	allowactivate	false
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
 }
 
 // SAVE BUTTON
 resource
 Button
 {
-	title			"Save"
 	name			"SaveButton"
-	rect			400 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			405 405 24 24
+	rect			465 386 64 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group; widgetcommand LoadSaveList savegame\n"
+	mouseEnterCmd	"widgetcommand DateTime title Guardar"
 	borderstyle		"NONE"
-	shader			"x_button_xbox"	
-	allowactivate	false
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
 }
 
 // DELETE BUTTON
 resource
 Button
 {
-	title			"Delete"
 	name			"DeleteButton"
-	rect			500 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
+	rect			561 382 64 64
+	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+//	stuffcommand	"widgetcommand LoadSaveList removegame"
+	stuffcommand	"widgetcommand LoadSaveList enablegroup delete_group\n"
+	mouseEnterCmd	"widgetcommand DateTime title Borrar"
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
+}
+
 resource
 Button
 {
-	name			"Default"
-	rect			505 405 24 24
+	name			"PrevButton"
+	rect			140 430 22 22
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_med
+	hovershader		ui/loadgame/pushbtn_med_lit
 	borderstyle		"NONE"
-	shader			"y_button_xbox"	
-	allowactivate	false
+	groupid			"lsd_group"
+	hoversound		"sound/ui/hover_3.wav"
+	stuffcommand	"widgetcommand PrevButton triggerwait\n"
+	clicksound		"sound/ui/projector_long.wav"
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
+	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
+	waitcommand		"widgetcommand LoadSaveList prevpage" 350
+}
+resource
+Button
+{
+	name			"NextButton"
+	rect			162 429 22 22
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_med
+	hovershader		ui/loadgame/pushbtn_med_lit
+	borderstyle		"NONE"
+	groupid			"lsd_group"
+	hoversound		"sound/ui/hover_3.wav"
+	stuffcommand	"widgetcommand NextButton triggerwait\n"
+	clicksound		"sound/ui/projector_long.wav"
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
+	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
+	waitcommand		"widgetcommand LoadSaveList nextpage" 350
 }
 
 resource
@@ -529,7 +570,7 @@ Label
 	fontangle		2.1
 	fontspacing		1
 	fontscale		0.85
-} 
+}
 
 resource
 Label
@@ -558,6 +599,7 @@ Label
 	shader			ui/load/deletetext
 	groupid			"delete_group"
 	disable
+	fadein			0.5
 }
 resource
 Button
@@ -582,46 +624,38 @@ Button
 	groupid			"delete_group"
 	disable
 	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group\n"
-} 
+}
 
 resource
 Label
 {
 	name			"DiskFull"
-	rect			358 197 256 64
+	rect			358 165 256 128
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			ui/load/disk_full
 	disable
-} 
+}
 
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Back"
+	title			"Volver"
 	name			"Default"
-	rect			500 355 100 35
+	rect			0 455 75 25
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			505 360 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"b_button_xbox"	
-	allowactivate	false
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
 }
+
 end.

--- a/assets/loc/ESN/base_s_VorpalFix/ui/newgame.urc
+++ b/assets/loc/ESN/base_s_VorpalFix/ui/newgame.urc
@@ -72,7 +72,7 @@ resource
 Button
 {
 	name			"easy"
-	rect			198 78 256 64
+	rect			257 75 128 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -86,7 +86,7 @@ resource
 Button
 {
 	name			"medium"
-	rect			198 153 256 64
+	rect			257 145 128 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -101,7 +101,7 @@ resource
 Button
 {
 	name			"hard"
-	rect			198 225 256 64
+	rect			257 223 128 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -116,7 +116,7 @@ resource
 Button
 {
 	name			"nightmare"
-	rect			198 298 256 64
+	rect			198 300 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -126,85 +126,25 @@ Button
 	hoversound		sound/ui/loadsave_h.wav
 	clicksound		sound/ui/loadsave_c.wav
 }
-// Button Callouts: 
-resource
-Button
-{
-	title			"Wechseln"
-	name			"Default"
-	rect			200 400 115 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			205 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"dpad_ps3"	
-	allowactivate	false
-}
-resource
-Button
-{
-	title			"Auswählen"
-	name			"Default"
-	rect			50 400 130 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			55 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
-	allowactivate	false
-}
+
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Zurück"
+	title			"Volver"
 	name			"Default"
-	rect			350 400 100 35
+	rect			0 455 75 25
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			355 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
 }
+
 end.

--- a/assets/loc/ESN/base_s_VorpalFix/ui/quit.urc
+++ b/assets/loc/ESN/base_s_VorpalFix/ui/quit.urc
@@ -1,0 +1,134 @@
+menu "quit"		640 480 NONE 0.5
+bgcolor			0 0 0 1
+borderstyle		NONE
+bgfill			0 0 0 1
+fullscreen		1
+fadeoverlay		0.5
+
+allowactivate	true
+keycommand		y quit
+keycommand		n popmenu
+
+// Background
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	0 ui/quit/quitA
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	1 ui/quit/quitB
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 0 128 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	2 ui/quit/quitC
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			0 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	3 ui/quit/quitD
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	4 ui/quit/quitE
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 256 128 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	5 ui/quit/quitF
+	allowactivate	false
+}
+
+// BUTTONS
+resource
+Button
+{
+	name			"Default"
+	rect			403 249 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"quit"
+	hovershader		"ui/quit/yes_glow"
+	allowactivate	true
+	ordernumber		1
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+resource
+Button
+{
+	name			"Default"
+	rect			471 253 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"popmenu"
+	hovershader		"ui/quit/no_glow"
+//	allowactivate	false
+	ordernumber		2
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+
+resource
+Button
+{
+	name			"Default"
+	rect			363 416 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"pushmenu credits"
+	hovershader		"ui/quit/credits_glow"
+//	allowactivate	false
+	ordernumber		3
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+
+end.

--- a/assets/loc/FRA/base_f_VorpalFix/ui/controls.urc
+++ b/assets/loc/FRA/base_f_VorpalFix/ui/controls.urc
@@ -12,7 +12,7 @@ showcommand "widgetcommand alice3d setanim idle_stand_rocktoes\n"
 allowactivate	true
 keycommand		1 "widgetcommand TitleBar activategroup group_video\n"
 keycommand		2 "widgetcommand TitleBar activategroup group_audio\n"
-keycommand		3 "widgetcommand TitleBar activategroup group_control_pc\n"
+keycommand		3 "widgetcommand TitleBar activategroup group_control\n"
 keycommand		4 "widgetcommand TitleBar activategroup group_game\n"
 
 // Mirror background
@@ -169,15 +169,20 @@ Label
 resource
 Button
 {
+	title			"Retour"
 	name			"Default"
-	rect			0 456 80 24
-	fgcolor			1.00 1.00 1.00 1.00
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/back_button
-	hovershader		ui/back_button_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
 	stuffcommand	"popmenu"
 	groupid			"group_main"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			25 5
+	fontscale		0.8
 	direction		from_bottom 0.5
 	allowactivate	false
 }
@@ -205,33 +210,9 @@ Label
 	borderstyle		"NONE"
 	shader			ui/control/head_2
 	groupid			"group_main"
-	
 	allowactivate	false
-} 
-resource
-Label
-{
-	name			"Default"
-	rect			75 330 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"ui/control/hslider_prev"
-	groupid			"group_main"
-	allowactivate	false
-} 
-resource
-Label
-{
-	name			"Default"
-	rect			257 330 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"ui/control/hslider_next"
-	groupid			"group_main"
-	allowactivate	false
-} 
+}
+
 // hotspots
 resource
 Button
@@ -241,7 +222,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		2
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_video\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_video\n"
 	groupid			"group_main"
@@ -254,7 +234,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		3
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_audio\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_audio\n"
 	groupid			"group_main"
@@ -267,9 +246,8 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		4
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_control\n"
-	stuffcommand	"widgetcommand TitleBar activategroup group_control_pc\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
 	groupid			"group_main"
 }
 resource
@@ -280,7 +258,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		1
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_game\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_game\n"
 	groupid			"group_main"
@@ -349,7 +326,7 @@ Label
 resource
 Button
 {
-	title			"Back"
+	title			"Retour"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -358,55 +335,29 @@ Button
 	shader			ui/buttons/apply
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_main\n"
-	groupid			"group_control_pc"
-	
+	groupid			"group_control"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		6
+	fontpos			37 8
 }
 
 // RESET BUTTON
 resource
 Button
 {
-	title			"Reset"
+	title			"Rétablir"
 	name			"Default"
-	rect			170 400 100 35
+	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			ui/buttons/apply
 	hovershader		ui/buttons/apply_hover
-	stuffcommand	"exec default_pc.cfg; vid_restart; popmenu 0\n"
-	groupid			"group_control_pc"
-	
+	stuffcommand	"exec default.cfg; vid_restart; popmenu 0\n"
+	groupid			"group_control"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		7
-}
-
-// JOYSTICK
-resource
-Button
-{
-	title			"Controller"
-	name			"Default"
-	rect			290 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
-	groupid			"group_control_pc"
-	
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			13 8
-	fontscale		0.8	
-	ordernumber		34
+	fontpos			33 8
 }
 
 // BIND LIST
@@ -419,211 +370,12 @@ FakkBindList
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"3D_BORDER"
-	filename		bind_pc.scr
+	filename		ui/bind.scr
 	font			"asrafel"
-	groupid			"group_control_pc"
-	ordernumber		5
+	groupid			"group_control"
+	ordernumber		1
 }
 
-resource
-Label
-{
-	name			"Default"
-	rect			0 0 640 480
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"controls_pc"
-	groupid			"group_control"
-}
-resource
-Label
-{
-	title			"Alt Attack / Climb Up"
-	name			"Default"
-	rect			0 140 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Next Weapon"
-	name			"Default"
-	rect			0 175 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Move"
-	name			"Default"
-	rect			0 270 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Menu Navigation"
-	name			"Default"
-	rect			120 376 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Turn / Aim"
-	name			"Default"
-	rect			350 376 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Attack / Climb Down"
-	name			"Default"
-	rect			467 290 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Jump / Swim Up"
-	name			"Default"
-	rect			467 260 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Use / Swim Down"
-	name			"Default"
-	rect			467 230 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Alt Attack / Climb Up"
-	name			"Default"
-	rect			467 202 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Prev Weapon"
-	name			"Default"
-	rect			467 175 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Attack / Climb Down"
-	name			"Default"
-	rect			467 140 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Pause / Exit Menu"
-	name			"Default"
-	rect			270 110 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Controls"
-	name			"Default"
-	rect			50 50 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left center
-	fontscale		2.0
-	dropshadow		1
-}
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			50 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_control_pc\n"
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	ordernumber		35
-} 
 // --------------------------------------
 // --------------------------------------
 // VIDEO GROUP
@@ -634,7 +386,7 @@ Button
 resource
 Button
 {
-	title			"Apply"
+	title			"Appliquer"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -644,18 +396,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_video; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_video"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		15
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Annuler"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -665,19 +416,18 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_video; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_video"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		16
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // RESOLUTION
 resource
 Label
 {
-	title			"Resolution"
-	name			"ResolutionTxt"
+	title			"Résolution"
+	name			"Default"
 	rect			68 78 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -685,7 +435,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -698,20 +447,24 @@ List
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		center top
-	
-
-	highlighttextwidget "ResolutionTxt"
-	ordernumber		8
 
 	linkcvar		"r_mode"
+	additem			3 640x480
+	additem			4 800x600
+	additem			5 960x720
+	additem			6 1024x768
+	additem			7 1152x864
+	additem			8 1280x1024
+	additem			9 1600x1200
+	additem			-1 Personnalisée
 }
 
 // COLOR DEPTH
 resource
 Label
 {
-	title			"Color Depth"
-	name			"ColorTxt"
+	title			"Couleurs"
+	name			"Default"
 	rect			68 118 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -719,7 +472,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -733,21 +485,17 @@ List
 	font			"asrafel"
 	fontjustify		center top
 
-	highlighttextwidget "ColorTxt"
-	ordernumber		9
-
 	linkcvar		"r_colorbits"
 	additem			16 16Bit
 	additem			32 32Bit
-	
 }
 
 // FULLSCREEN
 resource
 Label
 {
-	title			"Fullscreen"
-	name			"FullscreenTxt"
+	title			"Plein écran"
+	name			"Default"
 	rect			68 158 210 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -755,7 +503,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 CheckBox
@@ -770,19 +517,15 @@ CheckBox
 	fontjustify		right center
 	linkcvar		"r_fullscreen"
 
-	highlighttextwidget "FullscreenTxt"
-	ordernumber		10
-
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-	
 }
 
 // BRIGHTNESS
 resource
 Label
 {
-	title			"Brightness"
+	title			"Luminosité"
 	name			"Brightness"
 	rect			68 188 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -791,7 +534,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 Slider
@@ -807,17 +549,13 @@ Slider
 	setrange		.5 1.5
 	stepsize		.05
 	font			"asrafel"
-	
-
-	highlighttextwidget "Brightness"
-	ordernumber		11
 }
 
 // TEXTURE DETAIL
 resource
 Label
 {
-	title			"Texture Detail"
+	title			"Détail des textures"
 	name			"Texture_Detail"
 	rect			68 238 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -826,7 +564,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 Slider
@@ -842,17 +579,13 @@ Slider
 	setrange		3 0
 	stepsize		-1
 	font			"asrafel"
-	
-
-	highlighttextwidget "Texture_Detail"
-	ordernumber		12
 }
 
 // TEXTURE DEPTH
 resource
 Label
 {
-	title			"Texture Depth"
+	title			"Bits textures"
 	name			"Texture_Bits"
 	rect			68 278 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -861,7 +594,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -878,18 +610,14 @@ List
 	linkcvar		"r_texturebits"
 	additem			16 16Bit
 	additem			32 32Bit
-	
-
-	highlighttextwidget "Texture_Bits"
-	ordernumber		13
 }
 
 // DETAIL TEXTURES
 resource
 Label
 {
-	title			"Detail Textures"
-	name			"DetailTxt"
+	title			"Textures des détails"
+	name			"Default"
 	rect			68 338 210 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -897,7 +625,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 CheckBox
@@ -914,10 +641,6 @@ CheckBox
 
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-	
-
-	highlighttextwidget "DetailTxt"
-	ordernumber		14
 }
 
 // --------------------------------------
@@ -930,7 +653,7 @@ CheckBox
 resource
 Button
 {
-	title			"Apply"
+	title			"Appliquer"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -940,18 +663,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_audio; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_audio"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		23
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Annuler"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -961,19 +683,18 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_audio; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_audio"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		24
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // SOUND DRIVER
 resource
 Label
 {
-	title			"Sound Driver"
-	name			"DriverTxt"
+	title			"Pilote son"
+	name			"Default"
 	rect			68 78 200 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1001,16 +722,13 @@ List
 	additem			a3d2
 	additem			eax
 	additem			eax2
-
-	highlighttextwidget "DriverTxt"
-	ordernumber		17
 }
 
 // MUSIC VOLUME
 resource
 Label
 {
-	title			"Music Volume"
+	title			"Volume musique"
 	name			"Music_Volume"
 	rect			68 168 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1034,16 +752,13 @@ Slider
 	setrange		0 1
 	stepsize		.05
 	font			"asrafel"
-
-	highlighttextwidget "Music_Volume"
-	ordernumber		19
 }
 
 // SFX VOLUME
 resource
 Label
 {
-	title			"Effects Volume"
+	title			"Volume effets sonores"
 	name			"SFX_Volume"
 	rect			68 208 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1067,17 +782,14 @@ Slider
 	setrange		0 1
 	stepsize		.05
 	font			"asrafel"
-
-	highlighttextwidget "SFX_Volume"
-	ordernumber		20
 }
 
 // SPEAKER TYPE
 resource
 Label
 {
-	title			"Speaker Type"
-	name			"SpeakerTxt"
+	title			"Type haut-parleur"
+	name			"Default"
 	rect			68 118 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1100,20 +812,17 @@ List
 
 	linkcvar		"s_speaker_type"
 	additem			0 "Normal"
-	additem			1 "Headphones"
-	additem			3 "Surround"
-	additem			4 "Quad"
-
-	highlighttextwidget "SpeakerTxt"
-	ordernumber		18
+	additem			1 "Casque"
+	additem			3 "Son Surround"
+	additem			4 "4 haut-parleurs"
 }
 
 // QUALITY
 resource
 Label
 {
-	title			"Quality"
-	name			"QualityTxt"
+	title			"Qualité"
+	name			"Default"
 	rect			68 258 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1137,18 +846,14 @@ List
 	linkcvar		"s_khz"
 	additem			22 "22 khz"
 	additem			44 "44 khz"
-
-	highlighttextwidget "QualityTxt"
-	ordernumber		21
-
 }
 
 // FORCE 8BIT
 resource
 Label
 {
-	title			"Force 8bits"
-	name			"8BitsTxt"
+	title			"Son 8 bits"
+	name			"Default"
 	rect			68 298 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1172,9 +877,6 @@ CheckBox
 
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-
-	highlighttextwidget "8BitsTxt"
-	ordernumber		22
 }
 
 // --------------------------------------
@@ -1188,7 +890,7 @@ CheckBox
 resource
 Button
 {
-	title			"Apply"
+	title			"Appliquer"
 	name			"Default"
 	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1198,18 +900,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_game; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_game"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		32
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // CANCEL BUTTON
 resource
 Button
 {
-	title			"Cancel"
+	title			"Annuler"
 	name			"Default"
 	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1219,18 +920,17 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_game; toggleconsole; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_game"
-	
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	ordernumber		33
+	fontpos			30 8
+	fontscale		0.8
 }
 
 // SENSITIVITY
 resource
 Label
 {
-	title			"Sensitivity"
+	title			"Sensibilité"
 	name			"Mouse_Sensitivity"
 	rect			68 80 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1255,17 +955,14 @@ Slider
 	slidertype		float
 	stepsize		1
 	font			"asrafel"
-
-	highlighttextwidget "Mouse_Sensitivity"
-	ordernumber		25
 }
 
 // INVERT MOUSE
 resource
 Label
 {
-	title			"Invert Mouse"
-	name			"InvertMouseTxt"
+	title			"Inverser souris"
+	name			"Default"
 	rect			68 130 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1292,17 +989,13 @@ CheckBox
 
 	checked_command		"set m_pitch -0.022"
 	unchecked_command	"set m_pitch 0.022"
-
-	highlighttextwidget "InvertMouseTxt"
-	ordernumber		26
-
 }
 
 // CAMERA DISTANCE
 resource
 Label
 {
-	title			"Camera Distance"
+	title			"Distance caméra"
 	name			"Camera_Distance"
 	rect			68 158 220 24
 	fgcolor			0.199 0.043 0.043 1.00
@@ -1323,18 +1016,14 @@ Slider
 	setrange		76 192
 	stepsize		4
 	font			"asrafel"
-
-	highlighttextwidget "Camera_Distance"
-	ordernumber		27
-
 }
 
 // ALWAYS RUN
 resource
 Label
 {
-	title			"Always Run"
-	name			"AlwaysRunTxt"
+	title			"Course permanente"
+	name			"Default"
 	rect			68 210 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1358,18 +1047,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "AlwaysRunTxt"
-	ordernumber		28
-
 }
 
 // JUMP RETICLE
 resource
 Label
 {
-	title			"Jump Reticle"
-	name			"JumpReticleTxt"
+	title			"Réticule de saut"
 	rect			68 270 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1390,17 +1074,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "JumpReticleTxt"
-	ordernumber		29
 }
 
 // TARGET RETICLE
 resource
 Label
 {
-	title			"Target Reticle"
-	name			"TargetReticleTxt"
+	title			"Réticule de la cible"
 	rect			68 290 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1421,17 +1101,13 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "TargetReticleTxt"
-	ordernumber		30
 }
 
 // SUBTITLES
 resource
 Label
 {
-	title			"Subtitles"
-	name			"SubtitlesTxt"
+	title			"Sous-titrage"
 	rect			68 330 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1452,10 +1128,36 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
+}
 
-	highlighttextwidget "SubtitlesTxt"
-	ordernumber		31
+// CONSOLE
+resource
+Label
+{
+	title			"Console"
+	rect			68 350 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 350 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_console"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	checked_command		"toggleconsole\n"
+	unchecked_command	"toggleconsole\n"
 }
 
 end.
-ÍÍÍÂ¬

--- a/assets/loc/FRA/base_f_VorpalFix/ui/credits.urc
+++ b/assets/loc/FRA/base_f_VorpalFix/ui/credits.urc
@@ -3,11 +3,11 @@ fadeoverlay 0.5
 bgcolor 0 0 0 1
 borderstyle NONE
 bgfill 0 0 0 1
-fullscreen 1 
+fullscreen 1
 
 showcommand "widgetcommand page2 activategroup group_page1\n"
 showcommand "widgetcommand Rogue_Glow enable\n"
-showcommand "widgetcommand EA_Glow enable\n"
+showcommand "widgetcommand EA_Glow hide\n"
 showcommand	"widgetcommand title1 resetscroll\n"
 
 //waitcommand "widgetcommand page1 activategroup group_page2" 7000
@@ -52,7 +52,7 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	3 ui/credits/creditsE
-} 
+}
 
 // PAGE
 resource
@@ -99,7 +99,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	11 ui/credits/pageD
 	direction		from_point 0.5 250 0
-} 
+}
 
 // --------------------------------
 // PAGE1
@@ -109,7 +109,7 @@ AutoScroll
 {
 	title			"AutoScroll1"
 	name			"title1"
-	rect			30 95 246 280
+	rect			30 95 246 275
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -119,15 +119,15 @@ AutoScroll
 	fontspacing		0 -8
 	fontscale		0.90
 	direction		from_point 0.5 250 0
-	groupid			"group_page1" 
-	
-	scrollspeed		1.2 
-	
-	forcescissor 
-	
+	groupid			"group_page1"
+
+	scrollspeed		1.2
+
+	forcescissor
+
 	addimage		"ui/credits/alice" 96 5 64 128
 //	addimage		"ui/credits/rabbit" 60 130 128 128
-//	addimage		"ui/credits/bill" 138 154 128 128 
+//	addimage		"ui/credits/bill" 138 154 128 128
 
 	addline			" "
 	addline			" "
@@ -140,20 +140,21 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
-	
-	addline			"=== For Electronic Arts ==="
-	addline			" " 
-	
-	addline			"Design, Development, and Production"
+	addline			" "
+
+	addline			"=== Electronic Arts ==="
+	addline			" "
+
+	addline			"Conception, développement"
+	addline			"et production"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"American McGee"
 	addline			"R.J. Berg"
 	addline			"Billy Delli-Gatti"
 	addline			"Jordan David Maynard"
-	addline			" " 
-	
-	addline			"Marketing and Public Relations"
+	addline			" "
+
+	addline			"Marketing et relations publiques"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jonathan Harris"
 	addline			"Mike Jeffress"
@@ -161,13 +162,13 @@ AutoScroll
 	addline			"Jason S. Andersen"
 	addline			"Noreen Dante"
 	addline			"Gaylene Nagel"
-	addline			" " 
-	
-	addline			"Testing"
+	addline			" "
+
+	addline			"Tests"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"David McCormick, Lead"
-	addline			"Justin Holst, Asst. Lead"
-	addline			"Chad Schnittjer, Asst. Lead"
+	addline			"David McCormick, responsable"
+	addline			"Justin Holst, assistant responsable"
+	addline			"Chad Schnittjer, assistant responsable"
 	addline			"James Stanley"
 	addline			"Rad Christian"
 	addline			"Mike Kaiser"
@@ -181,25 +182,9 @@ AutoScroll
 	addline			"Seth Mespelli"
 	addline			"David Miller"
 	addline			"Rob Walker"
-	addline			" " 
-	
-	addline			"Localization Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Carole Celle"
-	addline			" " 
-	
-	addline			"Translation Coordinator"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Clare Parkes"
-	addline			"Rebecca Gordon"
-	addline			" " 
-	
-	addline			"Language Testing Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Sylvain Caburrosso"
-	addline			" " 
-	
-	addline			"Localization Testing"
+	addline			" "
+
+	addline			"Tests de localisation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Colin Clarke"
 	addline			"Daryl Humdy"
@@ -207,71 +192,73 @@ AutoScroll
 	addline			"Deni Skeens"
 	addline			"Christoph Betschart"
 	addline			"Roger Metcalf"
+	addline			"Timothy Johns"
 	addline			"Daren Hooper"
 	addline			"AC Martin"
-	addline			" " 
-	
-	addline			"Open & Close Cinematics"
+	addline			" "
+
+	addline			"Séquences cinématiques de"
+	addline			"début et de fin"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"by Little Beast"
+	addline			"de Little Beast"
 	addline			"San Francisco, CA"
-	addline			"R. Zane Rutledge, Director"
-	addline			"Matthew Fassberg, Producer"
-	addline			" " 
-	
-	addline			"Digital Matte Painting & Illustrations"
+	addline			"R. Zane Rutledge, directeur"
+	addline			"Matthew Fassberg, producteur"
+	addline			" "
+
+	addline			"Illustrations & peintures numériques"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"lxl"
-	addline			" " 
-	
-	addline			"Computer Animation"
+	addline			" "
+
+	addline			"Animations"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Matthew Hendershot"
 	addline			"Jamie Houk"
 	addline			"R. Zane Rutledge"
-	addline			" " 
-	
-	addline			"Music"
+	addline			" "
+
+	addline			"Musique"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Produced, Composed and Arranged"
-	addline			"by Chris Vrenna"
+	addline			"produite, composée et arrangée"
+	addline			"par Chris Vrenna"
 	addline			" "
-	addline			"Additional music programming &"
-	addline			"performance by Mark Blasquez"
+	addline			"Programmation de la musique"
+	addline			"complémentaire & interprétation"
+	addline			"de Mark Blasquez"
 	addline			" "
-	addline			"Additional girl choir performance"
-	addline			"by Jessicka"
-	addline			" " 
-	
-	addline			"Sound Design, Recording,"
-	addline			"Processing, and FX"
+	addline			"Choeur supplémentaire de Jessicka"
+	addline			" "
+
+	addline			"Conception du son, enregistrements,"
+	addline			"traitement et effets sonores"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ken Felton"
 	addline			"Marc Farley"
 	addline			"Mat Mitchell"
 	addline			"Aaron Thibault"
 	addline			"Stretch Williams"
-	addline			" " 
-	
-	addline			"Voice Talent"
+	addline			" "
+
+	addline			"Voix"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Susie Brann"
 	addline			"Roger Jackson"
 	addline			"Jarion Monroe"
 	addline			"Andrew Chaikin"
 	addline			"Anni Long"
-	addline			" " 
-	
-	addline			"International Development"
+	addline			" "
+
+	addline			"Dév. international du produit"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Atsuko Matsumoto"
 	addline			"Dan Roisman"
 	addline			"John Pemberton"
 	addline			"Gabriel Gils Carbo"
 	addline			"Lafayette Taylor"
-	addline			" " 
-	
-	addline			"Creative Services"
+	addline			" "
+
+	addline			"Département création"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Adrienne Rogers"
 	addline			"Kevin Marburg"
@@ -284,9 +271,9 @@ AutoScroll
 	addline			"Greg Roensch"
 	addline			"Ede Clarke"
 	addline			"Michael Kerbow - IMAGIC"
-	addline			" " 
-	
-	addline			"CAT Lab"
+	addline			" "
+
+	addline			"Laboratoire CAT"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"John Hanley"
 	addline			"Jacob Fernandez"
@@ -294,17 +281,17 @@ AutoScroll
 	addline			"Brian Sawyer"
 	addline			"Emiliano Miranda"
 	addline			"Dave Caron"
-	addline			" " 
-	
-	addline			"Mastering Lab"
+	addline			" "
+
+	addline			"Laboratoire de masterisation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Michael Yasko"
 	addline			"Yakim Hayuk"
 	addline			"Mike Dier"
 	addline			"Chris Espiritu"
-	addline			" " 
-	
-	addline			"Customer Quality Control"
+	addline			" "
+
+	addline			"Contrôle qualité consommateurs"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Andrew Young"
 	addline			"Benjamin Crick"
@@ -315,9 +302,87 @@ AutoScroll
 	addline			"Dave Kellum"
 	addline			"Benjamin Smith"
 	addline			"Anthony Barbagallo"
-	addline			" " 
-	
-	addline			"Special Thanks"
+	addline			" "
+
+	addline			"Chef de projet localisation"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Carole Celle"
+	addline			" "
+
+	addline			"Responsable localisation France"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Christine Jean"
+	addline			" "
+
+	addline			"Coordinatrice de la traduction"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Nathalie Duret"
+	addline			" "
+
+	addline			"Traduction"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Words of Magic"
+	addline			" "
+
+	addline			"Chef produit"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Raphaele Martinon"
+	addline			" "
+
+	addline			"Relations publiques"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Anne Vaganay"
+	addline			" "
+
+	addline			"Chef de projet tests localisation"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Sylvain Caburrosso"
+	addline			" "
+
+	addline			"Coordination du test de localisation"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lionel Berrodier"
+	addline			" "
+
+	addline			"Testeur LT"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lionel Berrodier"
+	addline			" "
+
+	addline			"Testeur CQC"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lionel Berrodier"
+	addline			" "
+
+	addline			"Contrôle qualité"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lionel Berrodier"
+	addline			" "
+
+	addline			"Responsable audio"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"David Lapp"
+	addline			" "
+
+	addline			"Studio d'enregistrement"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lotus Rose (Paris)"
+	addline			" "
+
+	addline			"Voix"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Véronique Desmadryl"
+	addline			"Gérard Rinaldi"
+	addline			"Pascal Renwick"
+	addline			"Régis Reuilhac"
+	addline			"Serge Thiriet"
+	addline			"Régine Teyssot"
+	addline			"Michel Muller"
+	addline			"Eric Legrand"
+	addline			"Gérard Dessalles"
+	addline			"Françoise Vatel"
+
+	addline			"Nous remercions particulièrement"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Hilleman, Terry Smith,"
 	addline			"Colin Boswell, Linda Matteson,"
@@ -330,8 +395,8 @@ AutoScroll
 	addline			"Quarium Inc., Leigh Matty,"
 	addline			"Erik Whiteford, Santiago Nunez"
 	addline			"Gerrit Velthoen, Tim Wilson"
-	addline			" " 
-	
+	addline			" "
+
 //	addimage		"ui/credits/rabbit" 60 0 128 128
 	addimage		"ui/credits/bill" 60 0 128 128
 	addline			" "
@@ -339,12 +404,12 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
-	
-	addline			"=== For Rogue Entertainment ==="
-	addline			" " 
-	
-	addline			"2D Art"
+	addline			" "
+
+	addline			"=== Rogue Entertainment ==="
+	addline			" "
+
+	addline			"Infographie 2D"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Fleider"
 	addline			"Christopher 'Derelict' Greenhaw"
@@ -353,18 +418,18 @@ AutoScroll
 	addline			"Stephen Hornback"
 	addline			"Aaron Smith"
 	addline			"Joel F. Thomas Jr."
-	addline			" " 
-	
-	addline			"3D Art/Animation"
+	addline			" "
+
+	addline			"Infographie 3D/animations"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jay Brushwood"
 	addline			"Jose Hernandez"
 	addline			"Steven Maines"
 	addline			"John Turner"
 	addline			"Sung Yi"
-	addline			" " 
-	
-	addline			"Level Design"
+	addline			" "
+
+	addline			"Conception des niveaux"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Christian Cummings"
 	addline			"Brandon James"
@@ -373,54 +438,55 @@ AutoScroll
 	addline			"Cameron Lamprecht"
 	addline			"Brian Patenaude"
 	addline			"Bobby Pavlock"
-	addline			" " 
-	
-	addline			"Design Support"
+	addline			" "
+
+	addline			"Assistance à la conception"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Zdim"
-	addline			" " 
-	
-	addline			"Programming"
+	addline			" "
+
+	addline			"Programmation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Sean Fleming"
 	addline			"Peter Mack"
 	addline			"Darin McNeil"
 	addline			"Joe Waters"
-	addline			" " 
-	
-	addline			"Producer"
+	addline			" "
+
+	addline			"Producteur"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jim Molinets"
-	addline			" " 
-	
-	addline			"Business"
+	addline			" "
+
+	addline			"Service commercial"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Barrett Alexander"
 	addline			"Matt Kelso"
 	addline			" "
-	
-	addline			"Very Special Thanks"
+
+	addline			"Nous remercions particulièrment"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ritual Entertainment:"
-	addline			"Beau Anderson, 3D Art"
-	addline			"Mark Dochtermann, Programming"
-	addline			"Jim Dosé, Programming"
-	addline			"Levelord, Level Design"
-	addline			"Patrick Hook, Level Design"
+	addline			"Beau Anderson, infographie 3D"
+	addline			"Mark Dochtermann, programmation"
+	addline			"Jim Dosé, programmation"
+	addline			"Levelord, conception des niveaux"
+	addline			"Patrick Hook, conception des niveaux"
 	addline			" "
-	
-	addline			"Valued Contributors"
+
+	addline			"Avec la contribution appréciée de"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Won Choi, Art"
-	addline			"Lee Dotson, 2D Art"
-	addline			"Ciara Gay,  Alice Animation Actor"
-	addline			"Will Loconto, Sound Design"
-	addline			"Patrick Magruder, Programming"
-	addline			"Mike O'Rourke, 3D Art"
-	addline			"Robert Selitto, Level Design"
-	addline			" " 
-	
-	addline			"Testing"
+	addline			"Won Choi, infographie"
+	addline			"Lee Dotson, infographie 2D"
+	addline			"Ciara Gay, actrice d'animation"
+	addline			"  dans le rôle d'Alice"
+	addline			"Will Loconto, conception du son"
+	addline			"Patrick Magruder, programmation"
+	addline			"Mike O'Rourke, infographie 3D"
+	addline			"Robert Selitto, conception des niveaux"
+	addline			" "
+
+	addline			"Testeur"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Brock Boutte"
 	addline			"Shane Boydston"
@@ -447,12 +513,8 @@ AutoScroll
 	addline			"Cliff Ritchey"
 	addline			"Karen 'Scout' Sparks"
 	addline			"Marlena Troncoso"
-	addline			" " 
-	
-	addline			"Dog"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Spike"
-} 
+	addline			" "
+}
 
 resource
 Button
@@ -464,10 +526,10 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll"
+	stuffcommand	"widgetcommand title1 resetscroll; widgetcommand EA_Glow hide; widgetcommand Rogue_Glow enable\n"
 	shader			ui/credits/ea_glow
 	hovershader		ui/credits/ea_logo.tga
-} 
+}
 
 resource
 Button
@@ -479,44 +541,12 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll 161"
+	stuffcommand	"widgetcommand title1 resetscroll 204; widgetcommand EA_Glow enable; widgetcommand Rogue_Glow hide\n"
 	shader			ui/credits/rogue_glow
 	hovershader		ui/credits/rogue_logo.tga
-} 
-
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			100 370 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	direction		from_point 0.5 250 0
-	groupid			"group_page1"
-	stuffcommand	"widgetcommand Rogue_Glow hide; widgetcommand EA_Glow hide; popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			105 375 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
-	direction		from_point 0.5 250 0
-	groupid			"group_page1"
 }
-//----------------------------------- 
+
+//-----------------------------------
 
 // MOUSE
 resource
@@ -558,5 +588,26 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	7 ui/credits/mouseF
-} 
+}
+
+// RETURN BUTTON
+resource
+Button
+{
+	title			"Retour"
+	name			"Default"
+	rect			0 455 75 25
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"widgetcommand Rogue_Glow hide; widgetcommand EA_Glow hide; popmenu"
+	font			"asrafel"
+	fontjustify		center center
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
+}
+
 end.

--- a/assets/loc/FRA/base_f_VorpalFix/ui/loadsave.urc
+++ b/assets/loc/FRA/base_f_VorpalFix/ui/loadsave.urc
@@ -5,7 +5,7 @@ borderstyle NONE
 bgfill 0 0 0 1
 fullscreen 1
 //fadein 0.5
-//vidmode 3 
+//vidmode 3
 
 //include "ui/common.inc"
 
@@ -13,8 +13,8 @@ showcommand		"widgetcommand LoadSaveList resetpage\n"
 showcommand		"widgetcommand LoadSaveList CheckErrorState\n"
 showcommand		"widgetcommand LoadSaveList disablegroup delete_group\n"
 showcommand		"widgetcommand LoadSaveList enablegroup bigshot_group\n"
-
-
+showcommand		"widgetcommand bigcover_left resetmotion out\n"
+showcommand		"widgetcommand bigcover_right resetmotion out\n"
 hidecommand		"widgetcommand MsgBackground disable; widgetcommand DiskFull disable\n"
 
 // List
@@ -63,6 +63,38 @@ Label
 	borderstyle		"NONE"
 	fadein			1.0
 	inversealpha
+}
+resource
+Label
+{
+	name			"bigcover_left"
+	rect			381 149 131 166
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/cover_left.tga
+//	staticshader	18 ui/load/lenscap
+	borderstyle		"NONE"
+	groupid			"bigshot_group"
+	disable
+	direction		from_point 0.180 -190 0
+	waitcommand		"widgetcommand bigcover_left resetmotion in" 0
+	waitcommand		"widgetcommand bigcover_left resetmotion out" 500
+}
+resource
+Label
+{
+	name			"bigcover_right"
+	rect			448 143 143 166
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/cover_right.tga
+//	staticshader	18 ui/load/lenscap
+	borderstyle		"NONE"
+	groupid			"bigshot_group"
+	disable
+	direction		from_point 0.180 190 0
+	waitcommand		"widgetcommand bigcover_right resetmotion in" 0
+	waitcommand		"widgetcommand bigcover_right resetmotion out" 500
 }
 
 // LOAD SHOTS
@@ -222,7 +254,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	5 ui/load/loadF
 	allowactivate	false
-} 
+}
 
 // 1st
 resource
@@ -251,8 +283,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -285,8 +317,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -319,8 +351,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -353,8 +385,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -387,8 +419,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -421,8 +453,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -432,87 +464,96 @@ Button
 resource
 Button
 {
-	title			"Load"
 	name			"LoadingButton"
-	rect			300 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			305 405 24 24
+	rect			369 389 64 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group; widgetcommand LoadSaveList loadgame\n"
+	mouseEnterCmd	"widgetcommand DateTime title Charger"
 	borderstyle		"NONE"
-	shader			"a_button_xbox"	
-	allowactivate	false
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
 }
 
 // SAVE BUTTON
 resource
 Button
 {
-	title			"Save"
 	name			"SaveButton"
-	rect			400 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			405 405 24 24
+	rect			465 386 64 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group; widgetcommand LoadSaveList savegame\n"
+	mouseEnterCmd	"widgetcommand DateTime title Sauvegarder"
 	borderstyle		"NONE"
-	shader			"x_button_xbox"	
-	allowactivate	false
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
 }
 
 // DELETE BUTTON
 resource
 Button
 {
-	title			"Delete"
 	name			"DeleteButton"
-	rect			500 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
+	rect			561 382 64 64
+	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+//	stuffcommand	"widgetcommand LoadSaveList removegame"
+	stuffcommand	"widgetcommand LoadSaveList enablegroup delete_group\n"
+	mouseEnterCmd	"widgetcommand DateTime title Supprimer"
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
+}
+
 resource
 Button
 {
-	name			"Default"
-	rect			505 405 24 24
+	name			"PrevButton"
+	rect			140 430 22 22
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_med
+	hovershader		ui/loadgame/pushbtn_med_lit
 	borderstyle		"NONE"
-	shader			"y_button_xbox"	
-	allowactivate	false
+	groupid			"lsd_group"
+	hoversound		"sound/ui/hover_3.wav"
+	stuffcommand	"widgetcommand PrevButton triggerwait\n"
+	clicksound		"sound/ui/projector_long.wav"
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
+	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
+	waitcommand		"widgetcommand LoadSaveList prevpage" 350
+}
+resource
+Button
+{
+	name			"NextButton"
+	rect			162 429 22 22
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_med
+	hovershader		ui/loadgame/pushbtn_med_lit
+	borderstyle		"NONE"
+	groupid			"lsd_group"
+	hoversound		"sound/ui/hover_3.wav"
+	stuffcommand	"widgetcommand NextButton triggerwait\n"
+	clicksound		"sound/ui/projector_long.wav"
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
+	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
+	waitcommand		"widgetcommand LoadSaveList nextpage" 350
 }
 
 resource
@@ -529,7 +570,7 @@ Label
 	fontangle		2.1
 	fontspacing		1
 	fontscale		0.85
-} 
+}
 
 resource
 Label
@@ -558,6 +599,7 @@ Label
 	shader			ui/load/deletetext
 	groupid			"delete_group"
 	disable
+	fadein			0.5
 }
 resource
 Button
@@ -582,46 +624,38 @@ Button
 	groupid			"delete_group"
 	disable
 	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group\n"
-} 
+}
 
 resource
 Label
 {
 	name			"DiskFull"
-	rect			358 197 256 64
+	rect			358 165 256 128
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			ui/load/disk_full
 	disable
-} 
+}
 
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Back"
+	title			"Retour"
 	name			"Default"
-	rect			500 355 100 35
+	rect			0 455 75 25
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			505 360 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"b_button_xbox"	
-	allowactivate	false
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
 }
+
 end.

--- a/assets/loc/FRA/base_f_VorpalFix/ui/newgame.urc
+++ b/assets/loc/FRA/base_f_VorpalFix/ui/newgame.urc
@@ -72,7 +72,7 @@ resource
 Button
 {
 	name			"easy"
-	rect			198 78 256 64
+	rect			262 80 128 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -86,7 +86,7 @@ resource
 Button
 {
 	name			"medium"
-	rect			198 153 256 64
+	rect			201 154 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -101,7 +101,7 @@ resource
 Button
 {
 	name			"hard"
-	rect			198 225 256 64
+	rect			205 223 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -116,7 +116,7 @@ resource
 Button
 {
 	name			"nightmare"
-	rect			198 298 256 64
+	rect			149 298 356 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -126,85 +126,25 @@ Button
 	hoversound		sound/ui/loadsave_h.wav
 	clicksound		sound/ui/loadsave_c.wav
 }
-// Button Callouts: 
-resource
-Button
-{
-	title			"Wechseln"
-	name			"Default"
-	rect			200 400 115 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			205 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"dpad_ps3"	
-	allowactivate	false
-}
-resource
-Button
-{
-	title			"Auswählen"
-	name			"Default"
-	rect			50 400 130 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			55 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
-	allowactivate	false
-}
+
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Zurück"
+	title			"Retour"
 	name			"Default"
-	rect			350 400 100 35
+	rect			0 455 75 25
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
+	shader			ui/buttons/tab
+	hovershader		ui/buttons/tab_hover
+	stuffcommand	"popmenu"
 	font			"asrafel"
 	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			355 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
+	fontpos			25 5
+	fontscale		0.8
+	direction		from_bottom 0.5
 }
+
 end.

--- a/assets/loc/FRA/base_f_VorpalFix/ui/quit.urc
+++ b/assets/loc/FRA/base_f_VorpalFix/ui/quit.urc
@@ -1,0 +1,134 @@
+menu "quit"		640 480 NONE 0.5
+bgcolor			0 0 0 1
+borderstyle		NONE
+bgfill			0 0 0 1
+fullscreen		1
+fadeoverlay		0.5
+
+allowactivate	true
+keycommand		y quit
+keycommand		n popmenu
+
+// Background
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	0 ui/quit/quitA
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	1 ui/quit/quitB
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 0 128 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	2 ui/quit/quitC
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			0 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	3 ui/quit/quitD
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	4 ui/quit/quitE
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 256 128 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	5 ui/quit/quitF
+	allowactivate	false
+}
+
+// BUTTONS
+resource
+Button
+{
+	name			"Default"
+	rect			410 251 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"quit"
+	hovershader		"ui/quit/yes_glow"
+	allowactivate	true
+	ordernumber		1
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+resource
+Button
+{
+	name			"Default"
+	rect			478 251 64 32
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"popmenu"
+	hovershader		"ui/quit/no_glow"
+//	allowactivate	false
+	ordernumber		2
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+
+resource
+Button
+{
+	name			"Default"
+	rect			351 411 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"pushmenu credits"
+	hovershader		"ui/quit/credits_glow"
+//	allowactivate	false
+	ordernumber		3
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+
+end.

--- a/assets/loc/INT/base_e_VorpalFix/ui/controls.urc
+++ b/assets/loc/INT/base_e_VorpalFix/ui/controls.urc
@@ -12,7 +12,7 @@ showcommand "widgetcommand alice3d setanim idle_stand_rocktoes\n"
 allowactivate	true
 keycommand		1 "widgetcommand TitleBar activategroup group_video\n"
 keycommand		2 "widgetcommand TitleBar activategroup group_audio\n"
-keycommand		3 "widgetcommand TitleBar activategroup group_control_pc\n"
+keycommand		3 "widgetcommand TitleBar activategroup group_control\n"
 keycommand		4 "widgetcommand TitleBar activategroup group_game\n"
 
 // Mirror background
@@ -205,33 +205,9 @@ Label
 	borderstyle		"NONE"
 	shader			ui/control/head_2
 	groupid			"group_main"
-	
 	allowactivate	false
-} 
-resource
-Label
-{
-	name			"Default"
-	rect			75 330 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"ui/control/hslider_prev"
-	groupid			"group_main"
-	allowactivate	false
-} 
-resource
-Label
-{
-	name			"Default"
-	rect			257 330 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"ui/control/hslider_next"
-	groupid			"group_main"
-	allowactivate	false
-} 
+}
+
 // hotspots
 resource
 Button
@@ -241,7 +217,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		2
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_video\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_video\n"
 	groupid			"group_main"
@@ -254,7 +229,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		3
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_audio\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_audio\n"
 	groupid			"group_main"
@@ -267,9 +241,8 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		4
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_control\n"
-	stuffcommand	"widgetcommand TitleBar activategroup group_control_pc\n"
+	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
 	groupid			"group_main"
 }
 resource
@@ -280,7 +253,6 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	ordernumber		1
 	mouseEnterCmd	"widgetcommand TitleBar shader ui/control/head_2_game\n"
 	stuffcommand	"widgetcommand TitleBar activategroup group_game\n"
 	groupid			"group_main"
@@ -358,12 +330,10 @@ Button
 	shader			ui/buttons/apply
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_main\n"
-	groupid			"group_control_pc"
-	
+	groupid			"group_control"
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			35 8
-	ordernumber		6
 }
 
 // RESET BUTTON
@@ -372,41 +342,17 @@ Button
 {
 	title			"Reset"
 	name			"Default"
-	rect			170 400 100 35
+	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	shader			ui/buttons/apply
 	hovershader		ui/buttons/apply_hover
-	stuffcommand	"exec default_pc.cfg; vid_restart; popmenu 0\n"
-	groupid			"group_control_pc"
-	
+	stuffcommand	"exec default.cfg; vid_restart; popmenu 0\n"
+	groupid			"group_control"
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			35 8
-	ordernumber		7
-}
-
-// JOYSTICK
-resource
-Button
-{
-	title			"Controller"
-	name			"Default"
-	rect			290 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	stuffcommand	"widgetcommand TitleBar activategroup group_control\n"
-	groupid			"group_control_pc"
-	
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			13 8
-	fontscale		0.8	
-	ordernumber		34
 }
 
 // BIND LIST
@@ -419,211 +365,12 @@ FakkBindList
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"3D_BORDER"
-	filename		bind_pc.scr
+	filename		ui/bind.scr
 	font			"asrafel"
-	groupid			"group_control_pc"
-	ordernumber		5
+	groupid			"group_control"
+	ordernumber		1
 }
 
-resource
-Label
-{
-	name			"Default"
-	rect			0 0 640 480
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"controls_pc"
-	groupid			"group_control"
-}
-resource
-Label
-{
-	title			"Alt Attack / Climb Up"
-	name			"Default"
-	rect			0 140 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Next Weapon"
-	name			"Default"
-	rect			0 175 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Move"
-	name			"Default"
-	rect			0 270 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Menu Navigation"
-	name			"Default"
-	rect			120 376 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		right center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Turn / Aim"
-	name			"Default"
-	rect			350 376 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Attack / Climb Down"
-	name			"Default"
-	rect			467 290 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Jump / Swim Up"
-	name			"Default"
-	rect			467 260 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Use / Swim Down"
-	name			"Default"
-	rect			467 230 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Alt Attack / Climb Up"
-	name			"Default"
-	rect			467 202 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Prev Weapon"
-	name			"Default"
-	rect			467 175 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Attack / Climb Down"
-	name			"Default"
-	rect			467 140 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left top
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Pause / Exit Menu"
-	name			"Default"
-	rect			270 110 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-}
-resource
-Label
-{
-	title			"Controls"
-	name			"Default"
-	rect			50 50 167 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		left center
-	fontscale		2.0
-	dropshadow		1
-}
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			50 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	stuffcommand	"widgetcommand alice3d setanim idle_stand_rocktoes; widgetcommand TitleBar activategroup group_control_pc\n"
-	groupid			"group_control"
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	ordernumber		35
-} 
 // --------------------------------------
 // --------------------------------------
 // VIDEO GROUP
@@ -644,11 +391,9 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_video; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_video"
-	
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			35 8
-	ordernumber		15
 }
 
 // CANCEL BUTTON
@@ -665,11 +410,9 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_video; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_video"
-	
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			35 8
-	ordernumber		16
 }
 
 // RESOLUTION
@@ -677,7 +420,7 @@ resource
 Label
 {
 	title			"Resolution"
-	name			"ResolutionTxt"
+	name			"Default"
 	rect			68 78 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -685,7 +428,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -698,12 +440,16 @@ List
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		center top
-	
-
-	highlighttextwidget "ResolutionTxt"
-	ordernumber		8
 
 	linkcvar		"r_mode"
+	additem			3 640x480
+	additem			4 800x600
+	additem			5 960x720
+	additem			6 1024x768
+	additem			7 1152x864
+	additem			8 1280x1024
+	additem			9 1600x1200
+	additem			-1 Custom
 }
 
 // COLOR DEPTH
@@ -711,7 +457,7 @@ resource
 Label
 {
 	title			"Color Depth"
-	name			"ColorTxt"
+	name			"Default"
 	rect			68 118 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -719,7 +465,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -733,13 +478,9 @@ List
 	font			"asrafel"
 	fontjustify		center top
 
-	highlighttextwidget "ColorTxt"
-	ordernumber		9
-
 	linkcvar		"r_colorbits"
 	additem			16 16Bit
 	additem			32 32Bit
-	
 }
 
 // FULLSCREEN
@@ -747,7 +488,7 @@ resource
 Label
 {
 	title			"Fullscreen"
-	name			"FullscreenTxt"
+	name			"Default"
 	rect			68 158 210 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -755,7 +496,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 CheckBox
@@ -770,12 +510,8 @@ CheckBox
 	fontjustify		right center
 	linkcvar		"r_fullscreen"
 
-	highlighttextwidget "FullscreenTxt"
-	ordernumber		10
-
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-	
 }
 
 // BRIGHTNESS
@@ -791,7 +527,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 Slider
@@ -807,10 +542,6 @@ Slider
 	setrange		.5 1.5
 	stepsize		.05
 	font			"asrafel"
-	
-
-	highlighttextwidget "Brightness"
-	ordernumber		11
 }
 
 // TEXTURE DETAIL
@@ -826,7 +557,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 Slider
@@ -842,10 +572,6 @@ Slider
 	setrange		3 0
 	stepsize		-1
 	font			"asrafel"
-	
-
-	highlighttextwidget "Texture_Detail"
-	ordernumber		12
 }
 
 // TEXTURE DEPTH
@@ -861,7 +587,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 List
@@ -878,10 +603,6 @@ List
 	linkcvar		"r_texturebits"
 	additem			16 16Bit
 	additem			32 32Bit
-	
-
-	highlighttextwidget "Texture_Bits"
-	ordernumber		13
 }
 
 // DETAIL TEXTURES
@@ -889,7 +610,7 @@ resource
 Label
 {
 	title			"Detail Textures"
-	name			"DetailTxt"
+	name			"Default"
 	rect			68 338 210 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -897,7 +618,6 @@ Label
 	groupid			"group_video"
 	font			"asrafel"
 	fontjustify		left center
-	
 }
 resource
 CheckBox
@@ -914,10 +634,6 @@ CheckBox
 
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-	
-
-	highlighttextwidget "DetailTxt"
-	ordernumber		14
 }
 
 // --------------------------------------
@@ -940,11 +656,9 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_audio; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_audio"
-	
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			35 8
-	ordernumber		23
 }
 
 // CANCEL BUTTON
@@ -961,11 +675,9 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_audio; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_audio"
-	
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			35 8
-	ordernumber		24
 }
 
 // SOUND DRIVER
@@ -973,7 +685,7 @@ resource
 Label
 {
 	title			"Sound Driver"
-	name			"DriverTxt"
+	name			"Default"
 	rect			68 78 200 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1001,9 +713,6 @@ List
 	additem			a3d2
 	additem			eax
 	additem			eax2
-
-	highlighttextwidget "DriverTxt"
-	ordernumber		17
 }
 
 // MUSIC VOLUME
@@ -1034,9 +743,6 @@ Slider
 	setrange		0 1
 	stepsize		.05
 	font			"asrafel"
-
-	highlighttextwidget "Music_Volume"
-	ordernumber		19
 }
 
 // SFX VOLUME
@@ -1067,9 +773,6 @@ Slider
 	setrange		0 1
 	stepsize		.05
 	font			"asrafel"
-
-	highlighttextwidget "SFX_Volume"
-	ordernumber		20
 }
 
 // SPEAKER TYPE
@@ -1077,7 +780,7 @@ resource
 Label
 {
 	title			"Speaker Type"
-	name			"SpeakerTxt"
+	name			"Default"
 	rect			68 118 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1103,9 +806,6 @@ List
 	additem			1 "Headphones"
 	additem			3 "Surround"
 	additem			4 "Quad"
-
-	highlighttextwidget "SpeakerTxt"
-	ordernumber		18
 }
 
 // QUALITY
@@ -1113,7 +813,7 @@ resource
 Label
 {
 	title			"Quality"
-	name			"QualityTxt"
+	name			"Default"
 	rect			68 258 220 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1137,10 +837,6 @@ List
 	linkcvar		"s_khz"
 	additem			22 "22 khz"
 	additem			44 "44 khz"
-
-	highlighttextwidget "QualityTxt"
-	ordernumber		21
-
 }
 
 // FORCE 8BIT
@@ -1148,7 +844,7 @@ resource
 Label
 {
 	title			"Force 8bits"
-	name			"8BitsTxt"
+	name			"Default"
 	rect			68 298 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1172,9 +868,6 @@ CheckBox
 
 	checked_shader		"ui/control/checkbox_checked"
 	unchecked_shader	"ui/control/checkbox_unchecked"
-
-	highlighttextwidget "8BitsTxt"
-	ordernumber		22
 }
 
 // --------------------------------------
@@ -1198,11 +891,9 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_setcvars group_game; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_game"
-	
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			35 8
-	ordernumber		32
 }
 
 // CANCEL BUTTON
@@ -1219,11 +910,9 @@ Button
 	hovershader		ui/buttons/apply_hover
 	stuffcommand	"ui_restorecvars group_game; toggleconsole; widgetcommand TitleBar activategroup group_main\n"
 	groupid			"group_game"
-	
 	font			"asrafel"
 	fontjustify		center center
 	fontpos			35 8
-	ordernumber		33
 }
 
 // SENSITIVITY
@@ -1255,9 +944,6 @@ Slider
 	slidertype		float
 	stepsize		1
 	font			"asrafel"
-
-	highlighttextwidget "Mouse_Sensitivity"
-	ordernumber		25
 }
 
 // INVERT MOUSE
@@ -1265,7 +951,7 @@ resource
 Label
 {
 	title			"Invert Mouse"
-	name			"InvertMouseTxt"
+	name			"Default"
 	rect			68 130 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1292,10 +978,6 @@ CheckBox
 
 	checked_command		"set m_pitch -0.022"
 	unchecked_command	"set m_pitch 0.022"
-
-	highlighttextwidget "InvertMouseTxt"
-	ordernumber		26
-
 }
 
 // CAMERA DISTANCE
@@ -1323,10 +1005,6 @@ Slider
 	setrange		76 192
 	stepsize		4
 	font			"asrafel"
-
-	highlighttextwidget "Camera_Distance"
-	ordernumber		27
-
 }
 
 // ALWAYS RUN
@@ -1334,7 +1012,7 @@ resource
 Label
 {
 	title			"Always Run"
-	name			"AlwaysRunTxt"
+	name			"Default"
 	rect			68 210 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1358,10 +1036,6 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "AlwaysRunTxt"
-	ordernumber		28
-
 }
 
 // JUMP RETICLE
@@ -1369,7 +1043,6 @@ resource
 Label
 {
 	title			"Jump Reticle"
-	name			"JumpReticleTxt"
 	rect			68 270 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1390,9 +1063,6 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "JumpReticleTxt"
-	ordernumber		29
 }
 
 // TARGET RETICLE
@@ -1400,7 +1070,6 @@ resource
 Label
 {
 	title			"Target Reticle"
-	name			"TargetReticleTxt"
 	rect			68 290 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1421,9 +1090,6 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
-
-	highlighttextwidget "TargetReticleTxt"
-	ordernumber		30
 }
 
 // SUBTITLES
@@ -1431,7 +1097,6 @@ resource
 Label
 {
 	title			"Subtitles"
-	name			"SubtitlesTxt"
 	rect			68 330 144 24
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
@@ -1452,10 +1117,36 @@ CheckBox
 
 	checked_shader	 "ui/control/checkbox_checked"
 	unchecked_shader "ui/control/checkbox_unchecked"
+}
 
-	highlighttextwidget "SubtitlesTxt"
-	ordernumber		31
+// CONSOLE
+resource
+Label
+{
+	title			"Console"
+	rect			68 350 144 24
+	fgcolor			0.199 0.043 0.043 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		left center
+}
+resource
+CheckBox
+{
+	rect			260 350 112 20
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	groupid			"group_game"
+	font			"asrafel"
+	fontjustify		right center
+	linkcvar		"ui_console"
+
+	checked_shader		"ui/control/checkbox_checked"
+	unchecked_shader	"ui/control/checkbox_unchecked"
+
+	checked_command		"toggleconsole\n"
+	unchecked_command	"toggleconsole\n"
 }
 
 end.
-อออยฌ

--- a/assets/loc/INT/base_e_VorpalFix/ui/credits.urc
+++ b/assets/loc/INT/base_e_VorpalFix/ui/credits.urc
@@ -3,11 +3,11 @@ fadeoverlay 0.5
 bgcolor 0 0 0 1
 borderstyle NONE
 bgfill 0 0 0 1
-fullscreen 1 
+fullscreen 1
 
 showcommand "widgetcommand page2 activategroup group_page1\n"
 showcommand "widgetcommand Rogue_Glow enable\n"
-showcommand "widgetcommand EA_Glow enable\n"
+showcommand "widgetcommand EA_Glow hide\n"
 showcommand	"widgetcommand title1 resetscroll\n"
 
 //waitcommand "widgetcommand page1 activategroup group_page2" 7000
@@ -52,7 +52,7 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	3 ui/credits/creditsE
-} 
+}
 
 // PAGE
 resource
@@ -99,7 +99,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	11 ui/credits/pageD
 	direction		from_point 0.5 250 0
-} 
+}
 
 // --------------------------------
 // PAGE1
@@ -119,15 +119,15 @@ AutoScroll
 	fontspacing		0 -8
 	fontscale		0.90
 	direction		from_point 0.5 250 0
-	groupid			"group_page1" 
-	
-	scrollspeed		1.2 
-	
-	forcescissor 
-	
+	groupid			"group_page1"
+
+	scrollspeed		1.2
+
+	forcescissor
+
 	addimage		"ui/credits/alice" 96 5 64 128
 //	addimage		"ui/credits/rabbit" 60 130 128 128
-//	addimage		"ui/credits/bill" 138 154 128 128 
+//	addimage		"ui/credits/bill" 138 154 128 128
 
 	addline			" "
 	addline			" "
@@ -140,19 +140,19 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
-	
+	addline			" "
+
 	addline			"=== For Electronic Arts ==="
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Design, Development, and Production"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"American McGee"
 	addline			"R.J. Berg"
 	addline			"Billy Delli-Gatti"
 	addline			"Jordan David Maynard"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Marketing and Public Relations"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jonathan Harris"
@@ -161,8 +161,8 @@ AutoScroll
 	addline			"Jason S. Andersen"
 	addline			"Noreen Dante"
 	addline			"Gaylene Nagel"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Testing"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"David McCormick, Lead"
@@ -181,24 +181,24 @@ AutoScroll
 	addline			"Seth Mespelli"
 	addline			"David Miller"
 	addline			"Rob Walker"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Localization Project Manager"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Carole Celle"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Translation Coordinator"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Clare Parkes"
 	addline			"Rebecca Gordon"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Language Testing Project Manager"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Sylvain Caburrosso"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Localization Testing"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Colin Clarke"
@@ -209,28 +209,28 @@ AutoScroll
 	addline			"Roger Metcalf"
 	addline			"Daren Hooper"
 	addline			"AC Martin"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Open & Close Cinematics"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"by Little Beast"
 	addline			"San Francisco, CA"
 	addline			"R. Zane Rutledge, Director"
 	addline			"Matthew Fassberg, Producer"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Digital Matte Painting & Illustrations"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"lxl"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Computer Animation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Matthew Hendershot"
 	addline			"Jamie Houk"
 	addline			"R. Zane Rutledge"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Music"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Produced, Composed and Arranged"
@@ -241,8 +241,8 @@ AutoScroll
 	addline			" "
 	addline			"Additional girl choir performance"
 	addline			"by Jessicka"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Sound Design, Recording,"
 	addline			"Processing, and FX"
 	addimage		"ui/bar" 47 -0.2 150 4
@@ -251,8 +251,8 @@ AutoScroll
 	addline			"Mat Mitchell"
 	addline			"Aaron Thibault"
 	addline			"Stretch Williams"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Voice Talent"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Susie Brann"
@@ -260,8 +260,8 @@ AutoScroll
 	addline			"Jarion Monroe"
 	addline			"Andrew Chaikin"
 	addline			"Anni Long"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"International Development"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Atsuko Matsumoto"
@@ -269,8 +269,8 @@ AutoScroll
 	addline			"John Pemberton"
 	addline			"Gabriel Gils Carbo"
 	addline			"Lafayette Taylor"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Creative Services"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Adrienne Rogers"
@@ -284,8 +284,8 @@ AutoScroll
 	addline			"Greg Roensch"
 	addline			"Ede Clarke"
 	addline			"Michael Kerbow - IMAGIC"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"CAT Lab"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"John Hanley"
@@ -294,16 +294,16 @@ AutoScroll
 	addline			"Brian Sawyer"
 	addline			"Emiliano Miranda"
 	addline			"Dave Caron"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Mastering Lab"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Michael Yasko"
 	addline			"Yakim Hayuk"
 	addline			"Mike Dier"
 	addline			"Chris Espiritu"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Customer Quality Control"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Andrew Young"
@@ -315,8 +315,8 @@ AutoScroll
 	addline			"Dave Kellum"
 	addline			"Benjamin Smith"
 	addline			"Anthony Barbagallo"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Special Thanks"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Hilleman, Terry Smith,"
@@ -330,8 +330,8 @@ AutoScroll
 	addline			"Quarium Inc., Leigh Matty,"
 	addline			"Erik Whiteford, Santiago Nunez"
 	addline			"Gerrit Velthoen, Tim Wilson"
-	addline			" " 
-	
+	addline			" "
+
 //	addimage		"ui/credits/rabbit" 60 0 128 128
 	addimage		"ui/credits/bill" 60 0 128 128
 	addline			" "
@@ -339,11 +339,11 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
-	
+	addline			" "
+
 	addline			"=== For Rogue Entertainment ==="
-	addline			" " 
-	
+	addline			" "
+
 	addline			"2D Art"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Fleider"
@@ -353,8 +353,8 @@ AutoScroll
 	addline			"Stephen Hornback"
 	addline			"Aaron Smith"
 	addline			"Joel F. Thomas Jr."
-	addline			" " 
-	
+	addline			" "
+
 	addline			"3D Art/Animation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jay Brushwood"
@@ -362,8 +362,8 @@ AutoScroll
 	addline			"Steven Maines"
 	addline			"John Turner"
 	addline			"Sung Yi"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Level Design"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Christian Cummings"
@@ -373,32 +373,32 @@ AutoScroll
 	addline			"Cameron Lamprecht"
 	addline			"Brian Patenaude"
 	addline			"Bobby Pavlock"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Design Support"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Zdim"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Programming"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Sean Fleming"
 	addline			"Peter Mack"
 	addline			"Darin McNeil"
 	addline			"Joe Waters"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Producer"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jim Molinets"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Business"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Barrett Alexander"
 	addline			"Matt Kelso"
 	addline			" "
-	
+
 	addline			"Very Special Thanks"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ritual Entertainment:"
@@ -408,7 +408,7 @@ AutoScroll
 	addline			"Levelord, Level Design"
 	addline			"Patrick Hook, Level Design"
 	addline			" "
-	
+
 	addline			"Valued Contributors"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Won Choi, Art"
@@ -418,8 +418,8 @@ AutoScroll
 	addline			"Patrick Magruder, Programming"
 	addline			"Mike O'Rourke, 3D Art"
 	addline			"Robert Selitto, Level Design"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Testing"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Brock Boutte"
@@ -447,12 +447,12 @@ AutoScroll
 	addline			"Cliff Ritchey"
 	addline			"Karen 'Scout' Sparks"
 	addline			"Marlena Troncoso"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Dog"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Spike"
-} 
+}
 
 resource
 Button
@@ -464,10 +464,10 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll"
+	stuffcommand	"widgetcommand title1 resetscroll; widgetcommand EA_Glow hide; widgetcommand Rogue_Glow enable\n"
 	shader			ui/credits/ea_glow
 	hovershader		ui/credits/ea_logo.tga
-} 
+}
 
 resource
 Button
@@ -479,44 +479,12 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll 161"
+	stuffcommand	"widgetcommand title1 resetscroll 161; widgetcommand EA_Glow enable; widgetcommand Rogue_Glow hide\n"
 	shader			ui/credits/rogue_glow
 	hovershader		ui/credits/rogue_logo.tga
-} 
-
-// RETURN BUTTON
-resource
-Button
-{
-	title			"Back"
-	name			"Default"
-	rect			100 370 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	direction		from_point 0.5 250 0
-	groupid			"group_page1"
-	stuffcommand	"widgetcommand Rogue_Glow hide; widgetcommand EA_Glow hide; popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			105 375 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
-	direction		from_point 0.5 250 0
-	groupid			"group_page1"
 }
-//----------------------------------- 
+
+//-----------------------------------
 
 // MOUSE
 resource
@@ -558,5 +526,21 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	7 ui/credits/mouseF
-} 
+}
+
+// RETURN BUTTON
+resource
+Button
+{
+	name			"Default"
+	rect			0 456 80 24
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	shader			ui/back_button
+	hovershader		ui/back_button_hover
+	stuffcommand	"widgetcommand Rogue_Glow hide; widgetcommand EA_Glow hide; popmenu"
+	direction		from_bottom 0.5
+}
+
 end.

--- a/assets/loc/INT/base_e_VorpalFix/ui/loadsave.urc
+++ b/assets/loc/INT/base_e_VorpalFix/ui/loadsave.urc
@@ -5,7 +5,7 @@ borderstyle NONE
 bgfill 0 0 0 1
 fullscreen 1
 //fadein 0.5
-//vidmode 3 
+//vidmode 3
 
 //include "ui/common.inc"
 
@@ -13,8 +13,8 @@ showcommand		"widgetcommand LoadSaveList resetpage\n"
 showcommand		"widgetcommand LoadSaveList CheckErrorState\n"
 showcommand		"widgetcommand LoadSaveList disablegroup delete_group\n"
 showcommand		"widgetcommand LoadSaveList enablegroup bigshot_group\n"
-
-
+showcommand		"widgetcommand bigcover_left resetmotion out\n"
+showcommand		"widgetcommand bigcover_right resetmotion out\n"
 hidecommand		"widgetcommand MsgBackground disable; widgetcommand DiskFull disable\n"
 
 // List
@@ -63,6 +63,38 @@ Label
 	borderstyle		"NONE"
 	fadein			1.0
 	inversealpha
+}
+resource
+Label
+{
+	name			"bigcover_left"
+	rect			381 149 131 166
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/cover_left.tga
+//	staticshader	18 ui/load/lenscap
+	borderstyle		"NONE"
+	groupid			"bigshot_group"
+	disable
+	direction		from_point 0.180 -190 0
+	waitcommand		"widgetcommand bigcover_left resetmotion in" 0
+	waitcommand		"widgetcommand bigcover_left resetmotion out" 500
+}
+resource
+Label
+{
+	name			"bigcover_right"
+	rect			448 143 143 166
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/cover_right.tga
+//	staticshader	18 ui/load/lenscap
+	borderstyle		"NONE"
+	groupid			"bigshot_group"
+	disable
+	direction		from_point 0.180 190 0
+	waitcommand		"widgetcommand bigcover_right resetmotion in" 0
+	waitcommand		"widgetcommand bigcover_right resetmotion out" 500
 }
 
 // LOAD SHOTS
@@ -222,7 +254,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	5 ui/load/loadF
 	allowactivate	false
-} 
+}
 
 // 1st
 resource
@@ -251,8 +283,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -285,8 +317,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -319,8 +351,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -353,8 +385,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -387,8 +419,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -421,8 +453,8 @@ Button
 	borderstyle		"NONE"
 	groupid			"lsd_group"
 	clicksound		"sound/ui/projector_long.wav"
-	
-
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
 	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
@@ -432,87 +464,96 @@ Button
 resource
 Button
 {
-	title			"Load"
 	name			"LoadingButton"
-	rect			300 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			305 405 24 24
+	rect			369 389 64 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group; widgetcommand LoadSaveList loadgame\n"
+	mouseEnterCmd	"widgetcommand DateTime title Load Game"
 	borderstyle		"NONE"
-	shader			"a_button_xbox"	
-	allowactivate	false
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
 }
 
 // SAVE BUTTON
 resource
 Button
 {
-	title			"Save"
 	name			"SaveButton"
-	rect			400 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			405 405 24 24
+	rect			465 386 64 64
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group; widgetcommand LoadSaveList savegame\n"
+	mouseEnterCmd	"widgetcommand DateTime title Save Game"
 	borderstyle		"NONE"
-	shader			"x_button_xbox"	
-	allowactivate	false
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
 }
 
 // DELETE BUTTON
 resource
 Button
 {
-	title			"Delete"
 	name			"DeleteButton"
-	rect			500 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
+	rect			561 382 64 64
+	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_large
+	hovershader		ui/loadgame/pushbtn_large_lit
+//	stuffcommand	"widgetcommand LoadSaveList removegame"
+	stuffcommand	"widgetcommand LoadSaveList enablegroup delete_group\n"
+	mouseEnterCmd	"widgetcommand DateTime title Delete Game"
 	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontscale		0.8
-	fontpos			35 8
-} 
+	hoversound		"sound/ui/hover_3.wav"
+	clicksound		"sound/ui/click_4.wav"
+	groupid			"lsd_group"
+}
+
 resource
 Button
 {
-	name			"Default"
-	rect			505 405 24 24
+	name			"PrevButton"
+	rect			140 430 22 22
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_med
+	hovershader		ui/loadgame/pushbtn_med_lit
 	borderstyle		"NONE"
-	shader			"y_button_xbox"	
-	allowactivate	false
+	groupid			"lsd_group"
+	hoversound		"sound/ui/hover_3.wav"
+	stuffcommand	"widgetcommand PrevButton triggerwait\n"
+	clicksound		"sound/ui/projector_long.wav"
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
+	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
+	waitcommand		"widgetcommand LoadSaveList prevpage" 350
+}
+resource
+Button
+{
+	name			"NextButton"
+	rect			162 429 22 22
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	shader			ui/load/pushbtn_med
+	hovershader		ui/loadgame/pushbtn_med_lit
+	borderstyle		"NONE"
+	groupid			"lsd_group"
+	hoversound		"sound/ui/hover_3.wav"
+	stuffcommand	"widgetcommand NextButton triggerwait\n"
+	clicksound		"sound/ui/projector_long.wav"
+	waitcommand		"widgetcommand bigcover_left triggerwait" 0
+	waitcommand		"widgetcommand bigcover_right triggerwait" 0
+	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
+	waitcommand		"widgetcommand LoadSaveList nextpage" 350
 }
 
 resource
@@ -529,7 +570,7 @@ Label
 	fontangle		2.1
 	fontspacing		1
 	fontscale		0.85
-} 
+}
 
 resource
 Label
@@ -558,6 +599,7 @@ Label
 	shader			ui/load/deletetext
 	groupid			"delete_group"
 	disable
+	fadein			0.5
 }
 resource
 Button
@@ -582,7 +624,7 @@ Button
 	groupid			"delete_group"
 	disable
 	stuffcommand	"widgetcommand LoadSaveList disablegroup delete_group\n"
-} 
+}
 
 resource
 Label
@@ -594,34 +636,21 @@ Label
 	borderstyle		"NONE"
 	shader			ui/load/disk_full
 	disable
-} 
+}
 
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Back"
 	name			"Default"
-	rect			500 355 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			505 360 24 24
+	rect			0 456 80 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"b_button_xbox"	
-	allowactivate	false
+	shader			ui/back_button
+	hovershader		ui/back_button_hover
+	stuffcommand	"popmenu"
+	direction		from_bottom 0.5
 }
+
 end.

--- a/assets/loc/INT/base_e_VorpalFix/ui/newgame.urc
+++ b/assets/loc/INT/base_e_VorpalFix/ui/newgame.urc
@@ -72,7 +72,7 @@ resource
 Button
 {
 	name			"easy"
-	rect			198 78 256 64
+	rect			205 81 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -86,7 +86,7 @@ resource
 Button
 {
 	name			"medium"
-	rect			198 153 256 64
+	rect			205 146 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -101,7 +101,7 @@ resource
 Button
 {
 	name			"hard"
-	rect			198 225 256 64
+	rect			205 212 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -116,7 +116,7 @@ resource
 Button
 {
 	name			"nightmare"
-	rect			198 298 256 64
+	rect			205 270 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -126,85 +126,20 @@ Button
 	hoversound		sound/ui/loadsave_h.wav
 	clicksound		sound/ui/loadsave_c.wav
 }
-// Button Callouts: 
-resource
-Button
-{
-	title			"Wechseln"
-	name			"Default"
-	rect			200 400 115 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			205 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"dpad_ps3"	
-	allowactivate	false
-}
-resource
-Button
-{
-	title			"Auswählen"
-	name			"Default"
-	rect			50 400 130 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			55 405 24 24
-	fgcolor			1.00 1.00 1.00 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
-	allowactivate	false
-}
+
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Zurück"
 	name			"Default"
-	rect			350 400 100 35
-	fgcolor			0.199 0.043 0.043 1.00
-	bgcolor			0.00 0.00 0.00 0.00
-	borderstyle		"NONE"
-	shader			ui/buttons/plaque
-	hovershader		ui/buttons/plaque_hover
-	font			"asrafel"
-	fontjustify		center center
-	fontpos			35 8
-	stuffcommand	"popmenu"
-} 
-resource
-Button
-{
-	name			"Default"
-	rect			355 405 24 24
+	rect			0 456 80 24
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
-	allowactivate	false
+	shader			ui/back_button
+	hovershader		ui/back_button_hover
+	stuffcommand	"popmenu"
+	direction		from_bottom 0.5
 }
+
 end.

--- a/assets/loc/INT/base_e_VorpalFix/ui/quit.urc
+++ b/assets/loc/INT/base_e_VorpalFix/ui/quit.urc
@@ -1,0 +1,134 @@
+menu "quit"		640 480 NONE 0.5
+bgcolor			0 0 0 1
+borderstyle		NONE
+bgfill			0 0 0 1
+fullscreen		1
+fadeoverlay		0.5
+
+allowactivate	true
+keycommand		y quit
+keycommand		n popmenu
+
+// Background
+resource
+Label
+{
+	name			"Default"
+	rect			0 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	0 ui/quit/quitA
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 0 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	1 ui/quit/quitB
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 0 128 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	2 ui/quit/quitC
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			0 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	3 ui/quit/quitD
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			256 256 256 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	4 ui/quit/quitE
+	allowactivate	false
+}
+resource
+Label
+{
+	name			"Default"
+	rect			512 256 128 224
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	staticshader	5 ui/quit/quitF
+	allowactivate	false
+}
+
+// BUTTONS
+resource
+Button
+{
+	name			"Default"
+	rect			417 167 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"quit"
+	hovershader		"ui/quit/yes_glow"
+	allowactivate	true
+	ordernumber		1
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+resource
+Button
+{
+	name			"Default"
+	rect			481 169 64 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"popmenu"
+	hovershader		"ui/quit/no_glow"
+//	allowactivate	false
+	ordernumber		2
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+
+resource
+Button
+{
+	name			"Default"
+	rect			352 235 256 64
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 0.00
+	borderstyle		"NONE"
+	stuffcommand	"pushmenu credits"
+	hovershader		"ui/quit/credits_glow"
+//	allowactivate	false
+	ordernumber		3
+	keycommand		y quit
+	keycommand		n popmenu
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
+}
+
+end.

--- a/assets/pak6_VorpalFix/DEU/loadsave2.urc
+++ b/assets/pak6_VorpalFix/DEU/loadsave2.urc
@@ -528,7 +528,7 @@ Label
 	fontjustify		left center
 	fontangle		2.1
 	fontspacing		1
-	fontscale		0.8
+	fontscale		0.85
 }
 
 resource

--- a/assets/pak6_VorpalFix/DEU/newgame2.urc
+++ b/assets/pak6_VorpalFix/DEU/newgame2.urc
@@ -150,7 +150,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"dpad_ps3"	
+	shader			"dpad_xbox"	
 	allowactivate	false
 }
 resource
@@ -176,7 +176,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
+	shader			"a_button_xbox"	
 	allowactivate	false
 }
 // RETURN BUTTON
@@ -204,7 +204,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/DEU_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/DEU_ps3/loadsave2.urc
@@ -528,7 +528,7 @@ Label
 	fontjustify		left center
 	fontangle		2.1
 	fontspacing		1
-	fontscale		0.8
+	fontscale		0.85
 }
 
 resource

--- a/assets/pak6_VorpalFix/ESN/credits2.urc
+++ b/assets/pak6_VorpalFix/ESN/credits2.urc
@@ -3,7 +3,7 @@ fadeoverlay 0.5
 bgcolor 0 0 0 1
 borderstyle NONE
 bgfill 0 0 0 1
-fullscreen 1 
+fullscreen 1
 
 showcommand "widgetcommand page2 activategroup group_page1\n"
 showcommand "widgetcommand Rogue_Glow enable\n"
@@ -52,7 +52,7 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	3 ui/credits/creditsE
-} 
+}
 
 // PAGE
 resource
@@ -99,7 +99,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	11 ui/credits/pageD
 	direction		from_point 0.5 250 0
-} 
+}
 
 // --------------------------------
 // PAGE1
@@ -109,7 +109,7 @@ AutoScroll
 {
 	title			"AutoScroll1"
 	name			"title1"
-	rect			30 95 246 280
+	rect			27 100 246 280
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -117,17 +117,17 @@ AutoScroll
 	fontjustify		center center
 //	fontangle		0.4
 	fontspacing		0 -8
-	fontscale		0.90
+	fontscale		0.85
 	direction		from_point 0.5 250 0
-	groupid			"group_page1" 
+	groupid			"group_page1"
 	
-	scrollspeed		1.2 
+	scrollspeed		1.2
 	
-	forcescissor 
+	forcescissor
 	
 	addimage		"ui/credits/alice" 96 5 64 128
 //	addimage		"ui/credits/rabbit" 60 130 128 128
-//	addimage		"ui/credits/bill" 138 154 128 128 
+//	addimage		"ui/credits/bill" 138 154 128 128
 
 	addline			" "
 	addline			" "
@@ -140,20 +140,20 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
+	addline			" "
 	
-	addline			"=== For Electronic Arts ==="
-	addline			" " 
+	addline			"=== Por Electronic Arts ==="
+	addline			" "
 	
-	addline			"Design, Development, and Production"
+	addline			"Diseño, Desarrollo y Producción"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"American McGee"
 	addline			"R.J. Berg"
 	addline			"Billy Delli-Gatti"
 	addline			"Jordan David Maynard"
-	addline			" " 
+	addline			" "
 	
-	addline			"Marketing and Public Relations"
+	addline			"Marketing y Relaciones Públicas"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jonathan Harris"
 	addline			"Mike Jeffress"
@@ -161,13 +161,13 @@ AutoScroll
 	addline			"Jason S. Andersen"
 	addline			"Noreen Dante"
 	addline			"Gaylene Nagel"
-	addline			" " 
+	addline			" "
 	
-	addline			"Testing"
+	addline			"Pruebas"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"David McCormick, Lead"
-	addline			"Justin Holst, Asst. Lead"
-	addline			"Chad Schnittjer, Asst. Lead"
+	addline			"David McCormick, Director"
+	addline			"Justin Holst, Asis. Dirección"
+	addline			"Chad Schnittjer, Asis. Dirección"
 	addline			"James Stanley"
 	addline			"Rad Christian"
 	addline			"Mike Kaiser"
@@ -180,26 +180,9 @@ AutoScroll
 	addline			"William Lane"
 	addline			"Seth Mespelli"
 	addline			"David Miller"
-	addline			"Rob Walker"
-	addline			" " 
-	
-	addline			"Localization Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Carole Celle"
-	addline			" " 
-	
-	addline			"Translation Coordinator"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Clare Parkes"
-	addline			"Rebecca Gordon"
-	addline			" " 
-	
-	addline			"Language Testing Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Sylvain Caburrosso"
-	addline			" " 
-	
-	addline			"Localization Testing"
+	addline			" "
+
+	addline			"Pruebas de Idioma"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Colin Clarke"
 	addline			"Daryl Humdy"
@@ -209,69 +192,79 @@ AutoScroll
 	addline			"Roger Metcalf"
 	addline			"Daren Hooper"
 	addline			"AC Martin"
-	addline			" " 
+	addline			"Timothy Johns"
+	addline			" "
 	
-	addline			"Open & Close Cinematics"
+	addline			"Secuencias Cinemáticas de"
+	addline			"Apertura y Cierre"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"by Little Beast"
+	addline			"por Little Beast"
 	addline			"San Francisco, CA"
 	addline			"R. Zane Rutledge, Director"
-	addline			"Matthew Fassberg, Producer"
-	addline			" " 
+	addline			"Matthew Fassberg, Productor"
+	addline			" "
 	
-	addline			"Digital Matte Painting & Illustrations"
+	addline			"Dibujo Digital e Ilustaciones"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"lxl"
-	addline			" " 
+	addline			" "
 	
-	addline			"Computer Animation"
+	addline			"Animaciones"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Matthew Hendershot"
 	addline			"Jamie Houk"
 	addline			"R. Zane Rutledge"
-	addline			" " 
+	addline			" "
 	
-	addline			"Music"
+	addline			"Música"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Produced, Composed and Arranged"
-	addline			"by Chris Vrenna"
+	addline			"Producida, Compuesta y Arreglada"
+	addline			"por Chris Vrenna"
 	addline			" "
-	addline			"Additional music programming &"
-	addline			"performance by Mark Blasquez"
+	addline			"Música adicional programada y"
+	addline			"realizada por Mark Blasquez"
 	addline			" "
-	addline			"Additional girl choir performance"
-	addline			"by Jessicka"
-	addline			" " 
+	addline			"Coro femenino realizado por Jessicka"
+	addline			" "
 	
-	addline			"Sound Design, Recording,"
-	addline			"Processing, and FX"
+	addline			"Diseño de Sonido, Grabaciones,"
+	addline			"Edición y Efectos"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ken Felton"
 	addline			"Marc Farley"
 	addline			"Mat Mitchell"
 	addline			"Aaron Thibault"
 	addline			"Stretch Williams"
-	addline			" " 
+	addline			" "
 	
-	addline			"Voice Talent"
+	addline			"Voces"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Susie Brann"
 	addline			"Roger Jackson"
 	addline			"Jarion Monroe"
 	addline			"Andrew Chaikin"
 	addline			"Anni Long"
-	addline			" " 
+	addline			"Sandra Jara"
+	addline			"Richar del Olmo"
+	addline			"Antonio Fernadez"
+	addline			"Elixabete Aldama"
+	addline			"David Bascones"
+	addline			"Regino Ramos"
+	addline			"Luis Paramo"
+	addline			"Julia Martinez"
+	addline			"Jaime Roca"
+	addline			" "
 	
-	addline			"International Development"
+	addline			"Desarrollo Internacional"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Atsuko Matsumoto"
 	addline			"Dan Roisman"
 	addline			"John Pemberton"
 	addline			"Gabriel Gils Carbo"
 	addline			"Lafayette Taylor"
-	addline			" " 
+	addline			" "
 	
-	addline			"Creative Services"
+	addline			"Servicios Creativos"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Adrienne Rogers"
 	addline			"Kevin Marburg"
@@ -284,27 +277,22 @@ AutoScroll
 	addline			"Greg Roensch"
 	addline			"Ede Clarke"
 	addline			"Michael Kerbow - IMAGIC"
-	addline			" " 
+	addline			" "
 	
-	addline			"CAT Lab"
+	addline			"Laboratorio CYT"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"John Hanley"
-	addline			"Jacob Fernandez"
-	addline			"Mark Gonzales"
-	addline			"Brian Sawyer"
-	addline			"Emiliano Miranda"
-	addline			"Dave Caron"
-	addline			" " 
+	addline			" "
 	
-	addline			"Mastering Lab"
+	addline			"Laboratorio de Masterización"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Michael Yasko"
 	addline			"Yakim Hayuk"
 	addline			"Mike Dier"
 	addline			"Chris Espiritu"
-	addline			" " 
+	addline			" "
 	
-	addline			"Customer Quality Control"
+	addline			"Control de Calidad"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Andrew Young"
 	addline			"Benjamin Crick"
@@ -315,9 +303,69 @@ AutoScroll
 	addline			"Dave Kellum"
 	addline			"Benjamin Smith"
 	addline			"Anthony Barbagallo"
-	addline			" " 
-	
-	addline			"Special Thanks"
+	addline			" "
+
+	addline			"Director Proyecto Localización"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Carole Celle"
+	addline			" "
+
+	addline			"Coordinador de Traducción"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"José Luis Rovira"
+	addline			" "
+
+	addline			"Traductor"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Cristina Macía"
+	addline			" "
+
+	addline			"Jefe de Producto"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Francesc Caparros"
+	addline			" "
+
+	addline			"Relaciones Públicas"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Oscar Frades"
+	addline			" "
+
+	addline			"Dirección Pruebas Idioma"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Sylvain Caburrosso"
+	addline			" "
+
+	addline			"Supervisor de Pruebas de Idiomas"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Luis Pinés"
+	addline			" "
+
+	addline			"Pruebas de Idioma"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"José Ramón Sagarna"
+	addline			" "
+
+	addline			"Supervisor Control Calidad"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Antonio Yago"
+	addline			" "
+
+	addline			"Control de Calidad"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Tomás Hermida"
+	addline			" "
+
+	addline			"Director de Audio"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"David Lapp"
+	addline			" "
+
+	addline			"Estudio de Grabación"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Taller de Sonido"
+	addline			" "
+
+	addline			"Agradecimientos Especiales"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Hilleman, Terry Smith,"
 	addline			"Colin Boswell, Linda Matteson,"
@@ -330,7 +378,7 @@ AutoScroll
 	addline			"Quarium Inc., Leigh Matty,"
 	addline			"Erik Whiteford, Santiago Nunez"
 	addline			"Gerrit Velthoen, Tim Wilson"
-	addline			" " 
+	addline			" "
 	
 //	addimage		"ui/credits/rabbit" 60 0 128 128
 	addimage		"ui/credits/bill" 60 0 128 128
@@ -339,12 +387,12 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
+	addline			" "
 	
-	addline			"=== For Rogue Entertainment ==="
-	addline			" " 
+	addline			"=== Por Rogue Entertainment ==="
+	addline			" "
 	
-	addline			"2D Art"
+	addline			"Diseño 2D"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Fleider"
 	addline			"Christopher 'Derelict' Greenhaw"
@@ -353,18 +401,18 @@ AutoScroll
 	addline			"Stephen Hornback"
 	addline			"Aaron Smith"
 	addline			"Joel F. Thomas Jr."
-	addline			" " 
+	addline			" "
 	
-	addline			"3D Art/Animation"
+	addline			"Diseño 3D/Animaciones"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jay Brushwood"
 	addline			"Jose Hernandez"
 	addline			"Steven Maines"
 	addline			"John Turner"
 	addline			"Sung Yi"
-	addline			" " 
+	addline			" "
 	
-	addline			"Level Design"
+	addline			"Diseño de Niveles"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Christian Cummings"
 	addline			"Brandon James"
@@ -373,54 +421,54 @@ AutoScroll
 	addline			"Cameron Lamprecht"
 	addline			"Brian Patenaude"
 	addline			"Bobby Pavlock"
-	addline			" " 
+	addline			" "
 	
-	addline			"Design Support"
+	addline			"Soporte del Diseño"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Zdim"
-	addline			" " 
+	addline			" "
 	
-	addline			"Programming"
+	addline			"Programación"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Sean Fleming"
 	addline			"Peter Mack"
 	addline			"Darin McNeil"
 	addline			"Joe Waters"
-	addline			" " 
+	addline			" "
 	
-	addline			"Producer"
+	addline			"Productor"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jim Molinets"
-	addline			" " 
+	addline			" "
 	
-	addline			"Business"
+	addline			"Negocios"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Barrett Alexander"
 	addline			"Matt Kelso"
 	addline			" "
-	
-	addline			"Very Special Thanks"
+
+	addline			"Agradecimientos Especiales"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ritual Entertainment:"
-	addline			"Beau Anderson, 3D Art"
-	addline			"Mark Dochtermann, Programming"
-	addline			"Jim Dosé, Programming"
-	addline			"Levelord, Level Design"
-	addline			"Patrick Hook, Level Design"
+	addline			"Beau Anderson, Diseño 3D"
+	addline			"Mark Dochtermann, Programación"
+	addline			"Jim Dosé, Programación"
+	addline			"Levelord, Diseño de Niveles"
+	addline			"Patrick Hook, Diseño de Niveles"
 	addline			" "
 	
-	addline			"Valued Contributors"
+	addline			"Colaboradores"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Won Choi, Art"
-	addline			"Lee Dotson, 2D Art"
-	addline			"Ciara Gay,  Alice Animation Actor"
-	addline			"Will Loconto, Sound Design"
-	addline			"Patrick Magruder, Programming"
-	addline			"Mike O'Rourke, 3D Art"
-	addline			"Robert Selitto, Level Design"
-	addline			" " 
+	addline			"Won Choi, Diseño"
+	addline			"Lee Dotson, Diseño 2D"
+	addline			"Ciara Gay, Actor de Animación de Alice"
+	addline			"Will Loconto, Diseño de Sonido"
+	addline			"Patrick Magruder, Programación"
+	addline			"Mike O'Rourke, Diseño 3D"
+	addline			"Robert Selitto, Diseño de Sonido"
+	addline			" "
 	
-	addline			"Testing"
+	addline			"Pruebas"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Brock Boutte"
 	addline			"Shane Boydston"
@@ -447,12 +495,8 @@ AutoScroll
 	addline			"Cliff Ritchey"
 	addline			"Karen 'Scout' Sparks"
 	addline			"Marlena Troncoso"
-	addline			" " 
-	
-	addline			"Dog"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Spike"
-} 
+	addline			" "
+}
 
 resource
 Button
@@ -467,7 +511,7 @@ Button
 	stuffcommand	"widgetcommand title1 resetscroll"
 	shader			ui/credits/ea_glow
 	hovershader		ui/credits/ea_logo.tga
-} 
+}
 
 resource
 Button
@@ -479,16 +523,16 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll 161"
+	stuffcommand	"widgetcommand title1 resetscroll 191"
 	shader			ui/credits/rogue_glow
 	hovershader		ui/credits/rogue_logo.tga
-} 
+}
 
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Back"
+	title			"Atrás"
 	name			"Default"
 	rect			100 370 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -511,12 +555,12 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
 }
-//----------------------------------- 
+//-----------------------------------
 
 // MOUSE
 resource

--- a/assets/pak6_VorpalFix/ESN/loadsave2.urc
+++ b/assets/pak6_VorpalFix/ESN/loadsave2.urc
@@ -528,7 +528,7 @@ Label
 	fontjustify		left center
 	fontangle		2.1
 	fontspacing		1
-	fontscale		0.8
+	fontscale		0.85
 }
 
 resource

--- a/assets/pak6_VorpalFix/ESN/newgame2.urc
+++ b/assets/pak6_VorpalFix/ESN/newgame2.urc
@@ -72,7 +72,7 @@ resource
 Button
 {
 	name			"easy"
-	rect			198 78 256 64
+	rect			257 75 128 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -86,7 +86,7 @@ resource
 Button
 {
 	name			"medium"
-	rect			198 153 256 64
+	rect			257 145 128 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -101,7 +101,7 @@ resource
 Button
 {
 	name			"hard"
-	rect			198 225 256 64
+	rect			257 223 128 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -116,7 +116,7 @@ resource
 Button
 {
 	name			"nightmare"
-	rect			198 298 256 64
+	rect			198 300 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -130,9 +130,9 @@ Button
 resource
 Button
 {
-	title			"Wechseln"
+	title			"Cambiar"
 	name			"Default"
-	rect			200 400 115 35
+	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -150,13 +150,13 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"dpad_ps3"	
+	shader			"dpad_xbox"	
 	allowactivate	false
 }
 resource
 Button
 {
-	title			"Auswählen"
+	title			"Seleccionar"
 	name			"Default"
 	rect			50 400 130 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -176,14 +176,14 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
+	shader			"a_button_xbox"	
 	allowactivate	false
 }
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Zurück"
+	title			"Atrás"
 	name			"Default"
 	rect			350 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -204,7 +204,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/ESN_ps3/credits2.urc
+++ b/assets/pak6_VorpalFix/ESN_ps3/credits2.urc
@@ -54,7 +54,6 @@ Label
 	staticshader	3 ui/credits/creditsE
 }
 
-
 // PAGE
 resource
 Label
@@ -121,9 +120,9 @@ AutoScroll
 	fontscale		0.85
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-
+	
 	scrollspeed		1.2
-
+	
 	forcescissor
 
 	addimage		"ui/credits/alice" 96 5 64 128
@@ -158,12 +157,12 @@ AutoScroll
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jonathan Harris"
 	addline			"Mike Jeffress"
-	addline			"Anne Marie Stein "
-	addline			"Jason S. Andersen "
+	addline			"Anne Marie Stein"
+	addline			"Jason S. Andersen"
 	addline			"Noreen Dante"
 	addline			"Gaylene Nagel"
 	addline			" "
-
+	
 	addline			"Pruebas"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"David McCormick, Director"
@@ -176,7 +175,7 @@ AutoScroll
 	addline			"Brian Barsda"
 	addline			"Donna Hunt"
 	addline			"Scott Ko"
-	addline			"Matt Dominguez "
+	addline			"Matt Dominguez"
 	addline			"Matt Ellison"
 	addline			"William Lane"
 	addline			"Seth Mespelli"
@@ -232,15 +231,15 @@ AutoScroll
 	addline			"Edición y Efectos"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ken Felton"
-	addline			"Marc Farley "
+	addline			"Marc Farley"
 	addline			"Mat Mitchell"
 	addline			"Aaron Thibault"
 	addline			"Stretch Williams"
 	addline			" "
-
+	
 	addline			"Voces"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Susie Brann "
+	addline			"Susie Brann"
 	addline			"Roger Jackson"
 	addline			"Jarion Monroe"
 	addline			"Andrew Chaikin"
@@ -255,7 +254,7 @@ AutoScroll
 	addline			"Julia Martinez"
 	addline			"Jaime Roca"
 	addline			" "
-
+	
 	addline			"Desarrollo Internacional"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Atsuko Matsumoto"
@@ -264,10 +263,10 @@ AutoScroll
 	addline			"Gabriel Gils Carbo"
 	addline			"Lafayette Taylor"
 	addline			" "
-
+	
 	addline			"Servicios Creativos"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Adrienne Rogers "
+	addline			"Adrienne Rogers"
 	addline			"Kevin Marburg"
 	addline			"Jennie Maruyama"
 	addline			"Mark Hausler"
@@ -524,10 +523,11 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll 189"
+	stuffcommand	"widgetcommand title1 resetscroll 191"
 	shader			ui/credits/rogue_glow
 	hovershader		ui/credits/rogue_logo.tga
 }
+
 // RETURN BUTTON
 resource
 Button

--- a/assets/pak6_VorpalFix/ESN_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/ESN_ps3/loadsave2.urc
@@ -528,7 +528,7 @@ Label
 	fontjustify		left center
 	fontangle		2.1
 	fontspacing		1
-	fontscale		0.8
+	fontscale		0.85
 }
 
 resource

--- a/assets/pak6_VorpalFix/ESN_ps3/newgame2.urc
+++ b/assets/pak6_VorpalFix/ESN_ps3/newgame2.urc
@@ -79,8 +79,8 @@ Button
 	hovershader		ui/newgame/easy_glow
 	ordernumber		1
 	stuffcommand	"seta skill 0; seta nextmap gvillage; cinematic opening.roq; togglemenu newgame;"
-	hoversound		sound/ui/mouseover.wav
-	clicksound		sound/ui/newclick.wav
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
 }
 resource
 Button
@@ -93,8 +93,8 @@ Button
 	hovershader		ui/newgame/medium_glow
 	ordernumber		2
 	stuffcommand	"seta skill 1; seta nextmap gvillage; cinematic opening.roq; togglemenu newgame;"
-	hoversound		sound/ui/mouseover.wav
-	clicksound		sound/ui/newclick.wav
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
 }
 
 resource
@@ -108,8 +108,8 @@ Button
 	hovershader		ui/newgame/hard_glow
 	ordernumber		3
 	stuffcommand	"seta skill 2; seta nextmap gvillage; cinematic opening.roq; togglemenu newgame;"
-	hoversound		sound/ui/mouseover.wav
-	clicksound		sound/ui/newclick.wav
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
 }
 
 resource
@@ -123,8 +123,8 @@ Button
 	hovershader		ui/newgame/nightmare_glow
 	ordernumber		4
 	stuffcommand	"seta skill 3; seta nextmap gvillage; cinematic opening.roq; togglemenu newgame;"
-	hoversound		sound/ui/mouseover.wav
-	clicksound		sound/ui/newclick.wav
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
 }
 // Button Callouts: 
 resource

--- a/assets/pak6_VorpalFix/FRA/credits2.urc
+++ b/assets/pak6_VorpalFix/FRA/credits2.urc
@@ -3,7 +3,7 @@ fadeoverlay 0.5
 bgcolor 0 0 0 1
 borderstyle NONE
 bgfill 0 0 0 1
-fullscreen 1 
+fullscreen 1
 
 showcommand "widgetcommand page2 activategroup group_page1\n"
 showcommand "widgetcommand Rogue_Glow enable\n"
@@ -52,7 +52,7 @@ Label
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
 	staticshader	3 ui/credits/creditsE
-} 
+}
 
 // PAGE
 resource
@@ -99,7 +99,7 @@ Label
 	borderstyle		"NONE"
 	staticshader	11 ui/credits/pageD
 	direction		from_point 0.5 250 0
-} 
+}
 
 // --------------------------------
 // PAGE1
@@ -109,7 +109,7 @@ AutoScroll
 {
 	title			"AutoScroll1"
 	name			"title1"
-	rect			30 95 246 280
+	rect			30 95 246 275
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -119,15 +119,15 @@ AutoScroll
 	fontspacing		0 -8
 	fontscale		0.90
 	direction		from_point 0.5 250 0
-	groupid			"group_page1" 
+	groupid			"group_page1"
 	
-	scrollspeed		1.2 
+	scrollspeed		1.2
 	
-	forcescissor 
+	forcescissor
 	
 	addimage		"ui/credits/alice" 96 5 64 128
 //	addimage		"ui/credits/rabbit" 60 130 128 128
-//	addimage		"ui/credits/bill" 138 154 128 128 
+//	addimage		"ui/credits/bill" 138 154 128 128
 
 	addline			" "
 	addline			" "
@@ -140,20 +140,21 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
+	addline			" "
 	
-	addline			"=== For Electronic Arts ==="
-	addline			" " 
+	addline			"=== Electronic Arts ==="
+	addline			" "
 	
-	addline			"Design, Development, and Production"
+	addline			"Conception, développement"
+	addline			"et production"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"American McGee"
 	addline			"R.J. Berg"
 	addline			"Billy Delli-Gatti"
 	addline			"Jordan David Maynard"
-	addline			" " 
+	addline			" "
 	
-	addline			"Marketing and Public Relations"
+	addline			"Marketing et relations publiques"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jonathan Harris"
 	addline			"Mike Jeffress"
@@ -161,13 +162,13 @@ AutoScroll
 	addline			"Jason S. Andersen"
 	addline			"Noreen Dante"
 	addline			"Gaylene Nagel"
-	addline			" " 
+	addline			" "
 	
-	addline			"Testing"
+	addline			"Tests"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"David McCormick, Lead"
-	addline			"Justin Holst, Asst. Lead"
-	addline			"Chad Schnittjer, Asst. Lead"
+	addline			"David McCormick, responsable"
+	addline			"Justin Holst, assistant responsable"
+	addline			"Chad Schnittjer, assistant responsable"
 	addline			"James Stanley"
 	addline			"Rad Christian"
 	addline			"Mike Kaiser"
@@ -181,25 +182,9 @@ AutoScroll
 	addline			"Seth Mespelli"
 	addline			"David Miller"
 	addline			"Rob Walker"
-	addline			" " 
-	
-	addline			"Localization Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Carole Celle"
-	addline			" " 
-	
-	addline			"Translation Coordinator"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Clare Parkes"
-	addline			"Rebecca Gordon"
-	addline			" " 
-	
-	addline			"Language Testing Project Manager"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Sylvain Caburrosso"
-	addline			" " 
-	
-	addline			"Localization Testing"
+	addline			" "
+
+	addline			"Tests de localisation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Colin Clarke"
 	addline			"Daryl Humdy"
@@ -207,71 +192,73 @@ AutoScroll
 	addline			"Deni Skeens"
 	addline			"Christoph Betschart"
 	addline			"Roger Metcalf"
+	addline			"Timothy Johns"
 	addline			"Daren Hooper"
 	addline			"AC Martin"
-	addline			" " 
+	addline			" "
 	
-	addline			"Open & Close Cinematics"
+	addline			"Séquences cinématiques de"
+	addline			"début et de fin"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"by Little Beast"
+	addline			"de Little Beast"
 	addline			"San Francisco, CA"
-	addline			"R. Zane Rutledge, Director"
-	addline			"Matthew Fassberg, Producer"
-	addline			" " 
+	addline			"R. Zane Rutledge, directeur"
+	addline			"Matthew Fassberg, producteur"
+	addline			" "
 	
-	addline			"Digital Matte Painting & Illustrations"
+	addline			"Illustrations & peintures numériques"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"lxl"
-	addline			" " 
+	addline			" "
 	
-	addline			"Computer Animation"
+	addline			"Animations"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Matthew Hendershot"
 	addline			"Jamie Houk"
 	addline			"R. Zane Rutledge"
-	addline			" " 
+	addline			" "
 	
-	addline			"Music"
+	addline			"Musique"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Produced, Composed and Arranged"
-	addline			"by Chris Vrenna"
+	addline			"produite, composée et arrangée"
+	addline			"par Chris Vrenna"
 	addline			" "
-	addline			"Additional music programming &"
-	addline			"performance by Mark Blasquez"
+	addline			"Programmation de la musique"
+	addline			"complémentaire & interprétation"
+	addline			"de Mark Blasquez"
 	addline			" "
-	addline			"Additional girl choir performance"
-	addline			"by Jessicka"
-	addline			" " 
+	addline			"Choeur supplémentaire de Jessicka"
+	addline			" "
 	
-	addline			"Sound Design, Recording,"
-	addline			"Processing, and FX"
+	addline			"Conception du son, enregistrements,"
+	addline			"traitement et effets sonores"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ken Felton"
 	addline			"Marc Farley"
 	addline			"Mat Mitchell"
 	addline			"Aaron Thibault"
 	addline			"Stretch Williams"
-	addline			" " 
+	addline			" "
 	
-	addline			"Voice Talent"
+	addline			"Voix"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Susie Brann"
 	addline			"Roger Jackson"
 	addline			"Jarion Monroe"
 	addline			"Andrew Chaikin"
 	addline			"Anni Long"
-	addline			" " 
+	addline			" "
 	
-	addline			"International Development"
+	addline			"Dév. international du produit"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Atsuko Matsumoto"
 	addline			"Dan Roisman"
 	addline			"John Pemberton"
 	addline			"Gabriel Gils Carbo"
 	addline			"Lafayette Taylor"
-	addline			" " 
+	addline			" "
 	
-	addline			"Creative Services"
+	addline			"Département création"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Adrienne Rogers"
 	addline			"Kevin Marburg"
@@ -284,9 +271,9 @@ AutoScroll
 	addline			"Greg Roensch"
 	addline			"Ede Clarke"
 	addline			"Michael Kerbow - IMAGIC"
-	addline			" " 
+	addline			" "
 	
-	addline			"CAT Lab"
+	addline			"Laboratoire CAT"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"John Hanley"
 	addline			"Jacob Fernandez"
@@ -294,17 +281,17 @@ AutoScroll
 	addline			"Brian Sawyer"
 	addline			"Emiliano Miranda"
 	addline			"Dave Caron"
-	addline			" " 
+	addline			" "
 	
-	addline			"Mastering Lab"
+	addline			"Laboratoire de masterisation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Michael Yasko"
 	addline			"Yakim Hayuk"
 	addline			"Mike Dier"
 	addline			"Chris Espiritu"
-	addline			" " 
+	addline			" "
 	
-	addline			"Customer Quality Control"
+	addline			"Contrôle qualité consommateurs"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Andrew Young"
 	addline			"Benjamin Crick"
@@ -315,9 +302,87 @@ AutoScroll
 	addline			"Dave Kellum"
 	addline			"Benjamin Smith"
 	addline			"Anthony Barbagallo"
-	addline			" " 
-	
-	addline			"Special Thanks"
+	addline			" "
+
+	addline			"Chef de projet localisation"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Carole Celle"
+	addline			" "
+
+	addline			"Responsable localisation France"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Christine Jean"
+	addline			" "
+
+	addline			"Coordinatrice de la traduction"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Nathalie Duret"
+	addline			" "
+
+	addline			"Traduction"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Words of Magic"
+	addline			" "
+
+	addline			"Chef produit"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Raphaele Martinon"
+	addline			" "
+
+	addline			"Relations publiques"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Anne Vaganay"
+	addline			" "
+
+	addline			"Chef de projet tests localisation"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Sylvain Caburrosso"
+	addline			" "
+
+	addline			"Coordination du test de localisation"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lionel Berrodier"
+	addline			" "
+
+	addline			"Testeur LT"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lionel Berrodier"
+	addline			" "
+
+	addline			"Testeur CQC"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lionel Berrodier"
+	addline			" "
+
+	addline			"Contrôle qualité"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lionel Berrodier"
+	addline			" "
+
+	addline			"Responsable audio"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"David Lapp"
+	addline			" "
+
+	addline			"Studio d'enregistrement"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Lotus Rose (Paris)"
+	addline			" "
+
+	addline			"Voix"
+	addimage		"ui/bar" 47 -0.2 150 4
+	addline			"Véronique Desmadryl"
+	addline			"Gérard Rinaldi"
+	addline			"Pascal Renwick"
+	addline			"Régis Reuilhac"
+	addline			"Serge Thiriet"
+	addline			"Régine Teyssot"
+	addline			"Michel Muller"
+	addline			"Eric Legrand"
+	addline			"Gérard Dessalles"
+	addline			"Françoise Vatel"
+
+	addline			"Nous remercions particulièrement"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Hilleman, Terry Smith,"
 	addline			"Colin Boswell, Linda Matteson,"
@@ -330,7 +395,7 @@ AutoScroll
 	addline			"Quarium Inc., Leigh Matty,"
 	addline			"Erik Whiteford, Santiago Nunez"
 	addline			"Gerrit Velthoen, Tim Wilson"
-	addline			" " 
+	addline			" "
 	
 //	addimage		"ui/credits/rabbit" 60 0 128 128
 	addimage		"ui/credits/bill" 60 0 128 128
@@ -339,12 +404,12 @@ AutoScroll
 	addline			" "
 	addline			" "
 	addline			" "
-	addline			" " 
+	addline			" "
 	
-	addline			"=== For Rogue Entertainment ==="
-	addline			" " 
+	addline			"=== Rogue Entertainment ==="
+	addline			" "
 	
-	addline			"2D Art"
+	addline			"Infographie 2D"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Rich Fleider"
 	addline			"Christopher 'Derelict' Greenhaw"
@@ -353,18 +418,18 @@ AutoScroll
 	addline			"Stephen Hornback"
 	addline			"Aaron Smith"
 	addline			"Joel F. Thomas Jr."
-	addline			" " 
+	addline			" "
 	
-	addline			"3D Art/Animation"
+	addline			"Infographie 3D/animations"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jay Brushwood"
 	addline			"Jose Hernandez"
 	addline			"Steven Maines"
 	addline			"John Turner"
 	addline			"Sung Yi"
-	addline			" " 
+	addline			" "
 	
-	addline			"Level Design"
+	addline			"Conception des niveaux"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Christian Cummings"
 	addline			"Brandon James"
@@ -373,54 +438,55 @@ AutoScroll
 	addline			"Cameron Lamprecht"
 	addline			"Brian Patenaude"
 	addline			"Bobby Pavlock"
-	addline			" " 
+	addline			" "
 	
-	addline			"Design Support"
+	addline			"Assistance à la conception"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Zdim"
-	addline			" " 
+	addline			" "
 	
-	addline			"Programming"
+	addline			"Programmation"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Sean Fleming"
 	addline			"Peter Mack"
 	addline			"Darin McNeil"
 	addline			"Joe Waters"
-	addline			" " 
+	addline			" "
 	
-	addline			"Producer"
+	addline			"Producteur"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jim Molinets"
-	addline			" " 
+	addline			" "
 	
-	addline			"Business"
+	addline			"Service commercial"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Barrett Alexander"
 	addline			"Matt Kelso"
 	addline			" "
-	
-	addline			"Very Special Thanks"
+
+	addline			"Nous remercions particulièrment"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ritual Entertainment:"
-	addline			"Beau Anderson, 3D Art"
-	addline			"Mark Dochtermann, Programming"
-	addline			"Jim Dosé, Programming"
-	addline			"Levelord, Level Design"
-	addline			"Patrick Hook, Level Design"
+	addline			"Beau Anderson, infographie 3D"
+	addline			"Mark Dochtermann, programmation"
+	addline			"Jim Dosé, programmation"
+	addline			"Levelord, conception des niveaux"
+	addline			"Patrick Hook, conception des niveaux"
 	addline			" "
 	
-	addline			"Valued Contributors"
+	addline			"Avec la contribution appréciée de"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Won Choi, Art"
-	addline			"Lee Dotson, 2D Art"
-	addline			"Ciara Gay,  Alice Animation Actor"
-	addline			"Will Loconto, Sound Design"
-	addline			"Patrick Magruder, Programming"
-	addline			"Mike O'Rourke, 3D Art"
-	addline			"Robert Selitto, Level Design"
-	addline			" " 
+	addline			"Won Choi, infographie"
+	addline			"Lee Dotson, infographie 2D"
+	addline			"Ciara Gay, actrice d'animation"
+	addline			"  dans le rôle d'Alice"
+	addline			"Will Loconto, conception du son"
+	addline			"Patrick Magruder, programmation"
+	addline			"Mike O'Rourke, infographie 3D"
+	addline			"Robert Selitto, conception des niveaux"
+	addline			" "
 	
-	addline			"Testing"
+	addline			"Testeur"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Brock Boutte"
 	addline			"Shane Boydston"
@@ -447,12 +513,8 @@ AutoScroll
 	addline			"Cliff Ritchey"
 	addline			"Karen 'Scout' Sparks"
 	addline			"Marlena Troncoso"
-	addline			" " 
-	
-	addline			"Dog"
-	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Spike"
-} 
+	addline			" "
+}
 
 resource
 Button
@@ -467,7 +529,7 @@ Button
 	stuffcommand	"widgetcommand title1 resetscroll"
 	shader			ui/credits/ea_glow
 	hovershader		ui/credits/ea_logo.tga
-} 
+}
 
 resource
 Button
@@ -479,16 +541,16 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll 161"
+	stuffcommand	"widgetcommand title1 resetscroll 204"
 	shader			ui/credits/rogue_glow
 	hovershader		ui/credits/rogue_logo.tga
-} 
+}
 
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Back"
+	title			"Retour"
 	name			"Default"
 	rect			100 370 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -511,12 +573,12 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
 }
-//----------------------------------- 
+//-----------------------------------
 
 // MOUSE
 resource

--- a/assets/pak6_VorpalFix/FRA/loadsave2.urc
+++ b/assets/pak6_VorpalFix/FRA/loadsave2.urc
@@ -528,7 +528,7 @@ Label
 	fontjustify		left center
 	fontangle		2.1
 	fontspacing		1
-	fontscale		0.8
+	fontscale		0.85
 }
 
 resource

--- a/assets/pak6_VorpalFix/FRA/newgame2.urc
+++ b/assets/pak6_VorpalFix/FRA/newgame2.urc
@@ -72,7 +72,7 @@ resource
 Button
 {
 	name			"easy"
-	rect			198 78 256 64
+	rect			262 80 128 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -86,7 +86,7 @@ resource
 Button
 {
 	name			"medium"
-	rect			198 153 256 64
+	rect			201 154 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -101,7 +101,7 @@ resource
 Button
 {
 	name			"hard"
-	rect			198 225 256 64
+	rect			205 223 256 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -116,7 +116,7 @@ resource
 Button
 {
 	name			"nightmare"
-	rect			198 298 256 64
+	rect			149 298 356 64
 	fgcolor			0.00 0.00 0.00 1.00
 	bgcolor			1.00 1.00 1.00 0.00
 	borderstyle		"NONE"
@@ -130,9 +130,9 @@ Button
 resource
 Button
 {
-	title			"Wechseln"
+	title			"Changer"
 	name			"Default"
-	rect			200 400 115 35
+	rect			200 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -150,15 +150,15 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"dpad_ps3"	
+	shader			"dpad_xbox"	
 	allowactivate	false
 }
 resource
 Button
 {
-	title			"Auswählen"
+	title			"Valider"
 	name			"Default"
-	rect			50 400 130 35
+	rect			50 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
@@ -176,14 +176,14 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"cross_button_ps3"	
+	shader			"a_button_xbox"	
 	allowactivate	false
-}
+} 
 // RETURN BUTTON
 resource
 Button
 {
-	title			"Zurück"
+	title			"Retour"
 	name			"Default"
 	rect			350 400 100 35
 	fgcolor			0.199 0.043 0.043 1.00
@@ -204,7 +204,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 }
 end.

--- a/assets/pak6_VorpalFix/FRA_ps3/credits2.urc
+++ b/assets/pak6_VorpalFix/FRA_ps3/credits2.urc
@@ -5,7 +5,7 @@ borderstyle NONE
 bgfill 0 0 0 1
 fullscreen 1
 
-showcommand "widgetcommand page2 activategroup group_page1"
+showcommand "widgetcommand page2 activategroup group_page1\n"
 showcommand "widgetcommand Rogue_Glow enable\n"
 showcommand "widgetcommand EA_Glow enable\n"
 showcommand	"widgetcommand title1 resetscroll\n"
@@ -53,7 +53,6 @@ Label
 	borderstyle		"NONE"
 	staticshader	3 ui/credits/creditsE
 }
-
 
 // PAGE
 resource
@@ -121,9 +120,9 @@ AutoScroll
 	fontscale		0.90
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-
+	
 	scrollspeed		1.2
-
+	
 	forcescissor
 
 	addimage		"ui/credits/alice" 96 5 64 128
@@ -159,12 +158,12 @@ AutoScroll
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Jonathan Harris"
 	addline			"Mike Jeffress"
-	addline			"Anne Marie Stein "
-	addline			"Jason S. Andersen "
+	addline			"Anne Marie Stein"
+	addline			"Jason S. Andersen"
 	addline			"Noreen Dante"
 	addline			"Gaylene Nagel"
 	addline			" "
-
+	
 	addline			"Tests"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"David McCormick, responsable"
@@ -177,7 +176,7 @@ AutoScroll
 	addline			"Brian Barsda"
 	addline			"Donna Hunt"
 	addline			"Scott Ko"
-	addline			"Matt Dominguez "
+	addline			"Matt Dominguez"
 	addline			"Matt Ellison"
 	addline			"William Lane"
 	addline			"Seth Mespelli"
@@ -235,21 +234,21 @@ AutoScroll
 	addline			"traitement et effets sonores"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Ken Felton"
-	addline			"Marc Farley "
+	addline			"Marc Farley"
 	addline			"Mat Mitchell"
 	addline			"Aaron Thibault"
 	addline			"Stretch Williams"
 	addline			" "
-
+	
 	addline			"Voix"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Susie Brann "
+	addline			"Susie Brann"
 	addline			"Roger Jackson"
 	addline			"Jarion Monroe"
 	addline			"Andrew Chaikin"
 	addline			"Anni Long"
 	addline			" "
-
+	
 	addline			"Dév. international du produit"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Atsuko Matsumoto"
@@ -258,10 +257,10 @@ AutoScroll
 	addline			"Gabriel Gils Carbo"
 	addline			"Lafayette Taylor"
 	addline			" "
-
+	
 	addline			"Département création"
 	addimage		"ui/bar" 47 -0.2 150 4
-	addline			"Adrienne Rogers "
+	addline			"Adrienne Rogers"
 	addline			"Kevin Marburg"
 	addline			"Jennie Maruyama"
 	addline			"Mark Hausler"
@@ -542,10 +541,11 @@ Button
 	borderstyle		"NONE"
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"
-	stuffcommand	"widgetcommand title1 resetscroll 199"
+	stuffcommand	"widgetcommand title1 resetscroll 204"
 	shader			ui/credits/rogue_glow
 	hovershader		ui/credits/rogue_logo.tga
 }
+
 // RETURN BUTTON
 resource
 Button

--- a/assets/pak6_VorpalFix/FRA_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/FRA_ps3/loadsave2.urc
@@ -53,6 +53,17 @@ Label
 	borderstyle		"NONE"
 	groupid			"bigshot_group"
 }
+resource
+Label
+{
+	name			"bigcover_black"
+	rect			358 101 256 256
+	fgcolor			1.00 1.00 1.00 1.00
+	bgcolor			0.00 0.00 0.00 1.00
+	borderstyle		"NONE"
+	fadein			1.0
+	inversealpha
+}
 
 // LOAD SHOTS
 resource
@@ -244,7 +255,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 1" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 2st
@@ -278,7 +289,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 2" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 3rd
@@ -312,7 +323,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 3" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 4th
@@ -346,7 +357,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 4" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 5th
@@ -380,7 +391,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 5" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // 6th
@@ -414,7 +425,7 @@ Button
 
 	waitcommand		"widgetcommand LoadSaveList disablegroup delete_group" 0
 	waitcommand		"widgetcommand LoadSaveList selecttab 6" 350
-
+	waitcommand		"widgetcommand bigcover_black resetmotion in" 350
 }
 
 // LOAD BUTTONS
@@ -517,7 +528,7 @@ Label
 	fontjustify		left center
 	fontangle		2.1
 	fontspacing		1
-	fontscale		0.8
+	fontscale		0.85
 }
 
 resource

--- a/assets/pak6_VorpalFix/FRA_ps3/newgame2.urc
+++ b/assets/pak6_VorpalFix/FRA_ps3/newgame2.urc
@@ -79,8 +79,8 @@ Button
 	hovershader		ui/newgame/easy_glow
 	ordernumber		1
 	stuffcommand	"seta skill 0; seta nextmap gvillage; cinematic opening.roq; togglemenu newgame;"
-	hoversound		sound/ui/mouseover.wav
-	clicksound		sound/ui/newclick.wav
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
 }
 resource
 Button
@@ -93,8 +93,8 @@ Button
 	hovershader		ui/newgame/medium_glow
 	ordernumber		2
 	stuffcommand	"seta skill 1; seta nextmap gvillage; cinematic opening.roq; togglemenu newgame;"
-	hoversound		sound/ui/mouseover.wav
-	clicksound		sound/ui/newclick.wav
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
 }
 
 resource
@@ -108,8 +108,8 @@ Button
 	hovershader		ui/newgame/hard_glow
 	ordernumber		3
 	stuffcommand	"seta skill 2; seta nextmap gvillage; cinematic opening.roq; togglemenu newgame;"
-	hoversound		sound/ui/mouseover.wav
-	clicksound		sound/ui/newclick.wav
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
 }
 
 resource
@@ -123,8 +123,8 @@ Button
 	hovershader		ui/newgame/nightmare_glow
 	ordernumber		4
 	stuffcommand	"seta skill 3; seta nextmap gvillage; cinematic opening.roq; togglemenu newgame;"
-	hoversound		sound/ui/mouseover.wav
-	clicksound		sound/ui/newclick.wav
+	hoversound		sound/ui/loadsave_h.wav
+	clicksound		sound/ui/loadsave_c.wav
 }
 // Button Callouts: 
 resource

--- a/assets/pak6_VorpalFix/INT/credits2.urc
+++ b/assets/pak6_VorpalFix/INT/credits2.urc
@@ -187,18 +187,18 @@ AutoScroll
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Carole Celle"
 	addline			" " 
-	
+
 	addline			"Translation Coordinator"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Clare Parkes"
 	addline			"Rebecca Gordon"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Language Testing Project Manager"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Sylvain Caburrosso"
-	addline			" " 
-	
+	addline			" "
+
 	addline			"Localization Testing"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Colin Clarke"
@@ -448,7 +448,7 @@ AutoScroll
 	addline			"Karen 'Scout' Sparks"
 	addline			"Marlena Troncoso"
 	addline			" " 
-	
+
 	addline			"Dog"
 	addimage		"ui/bar" 47 -0.2 150 4
 	addline			"Spike"
@@ -511,7 +511,7 @@ Button
 	fgcolor			1.00 1.00 1.00 1.00
 	bgcolor			0.00 0.00 0.00 0.00
 	borderstyle		"NONE"
-	shader			"circle_button_ps3"	
+	shader			"b_button_xbox"	
 	allowactivate	false
 	direction		from_point 0.5 250 0
 	groupid			"group_page1"

--- a/assets/pak6_VorpalFix/INT_ps3/loadsave2.urc
+++ b/assets/pak6_VorpalFix/INT_ps3/loadsave2.urc
@@ -528,7 +528,7 @@ Label
 	fontjustify		left center
 	fontangle		2.1
 	fontspacing		1
-	fontscale		0.8
+	fontscale		0.85
 } 
 
 resource


### PR DESCRIPTION
Here's a changelog of everything included in this Pull-request (I hope I don't forget to mention anything):
PC:
- The "Back" button is now consistently animated in every menu and every language to appear from the bottom (and go away when leaving).
- The New Game menu now has the right hover and click sounds in every language and not just English (although the clicking is never played due to the start of the cinematic).
- I fixed the original Controls screens since they barely take any space and just in case.
- The Quit screen no longer has a Back button (as it's pointless).
- Credits buttons (EA and Rogue) functions are now consistent in every language.
- The Rogue button in the Credits screen now jumps to the right line in every language.

Console:
- Fixed the hover and click sounds in the New Game screen (they are not used with a controller but just in case).
- Changed the Map Name font scale back to 0.85 (like in the PC version) in the loadsave screen.
- Credits buttons (EA and Rogue) are now simultaneously activated in every language to show off (they can't be activated at all, but their lines are also corrected just in case).
- (French PS3 ONLY) Added the black TV effects to the loadsave screen that I missed last time.

Both:
- The fade in from black is now applied to every menu screen (in every language) except for the main menu.
- Some unnecessary spaces removed in the Credits' text.

As you can see this PR mostly adds consistency to animations and effects, and various just in case scenarios. Hope everything is correct and in the right location.